### PR TITLE
implement add meal entry to current meal

### DIFF
--- a/apps/carbotracker/firestore.rules
+++ b/apps/carbotracker/firestore.rules
@@ -14,5 +14,9 @@ service cloud.firestore {
       allow read, update, delete: if isDocOwner(request, resource)
       allow create: if documentCreatorIsRequester(request)
     }
+
+    match /current-meals/{currentMealId}  {   
+      allow read, write: if true
+    } 
   }
 }

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
@@ -4,7 +4,7 @@
     <input
       name="amount"
       required
-      min="0.1"
+      min="1"
       type="number"
       [(ngModel)]="model.amount"
       matInput

--- a/apps/carbotracker/src/current-meal-feature/pages/CurrentMealPage/current-meal-page.component.html
+++ b/apps/carbotracker/src/current-meal-feature/pages/CurrentMealPage/current-meal-page.component.html
@@ -5,7 +5,7 @@
       <mat-list-item (click)="onMealEntryClick(mealEntry)">
         <h4 matListItemTitle>{{ mealEntry.name }}</h4>
         <p matListItemLine>
-          <span>{{ mealEntry.carbs }}g</span>
+          <span>{{ mealEntry.amount }}g</span>
         </p>
       </mat-list-item>
     }

--- a/apps/carbotracker/src/current-meal-feature/services/current-meal.service.ts
+++ b/apps/carbotracker/src/current-meal-feature/services/current-meal.service.ts
@@ -6,7 +6,7 @@ import {
   doc,
   getFirestore,
   onSnapshot,
-  updateDoc,
+  setDoc
 } from 'firebase/firestore';
 import { from } from 'rxjs';
 import { CurrentMealApiActions as ApiActions } from '../+state/current-meal.actions';
@@ -24,7 +24,7 @@ export class CurrentMealService {
   }) {
     const mealEntries = [...params.currentMeal.mealEntries, params.mealEntry];
     const document = this.getCurrentMealDocument(params);
-    return from(updateDoc(document, { mealEntries }));
+    return from(setDoc(document, { mealEntries }));
   }
 
   public subscribeToOwnCurrentMeal(params: { uid: string }) {

--- a/apps/carbotracker/src/current-meal-feature/services/current-meal.service.ts
+++ b/apps/carbotracker/src/current-meal-feature/services/current-meal.service.ts
@@ -6,7 +6,7 @@ import {
   doc,
   getFirestore,
   onSnapshot,
-  setDoc
+  setDoc,
 } from 'firebase/firestore';
 import { from } from 'rxjs';
 import { CurrentMealApiActions as ApiActions } from '../+state/current-meal.actions';


### PR DESCRIPTION
- **add entry to current meal and update firestore rules (but not yet correctly restricted at the moment)**
- **use amount instead of carbs on current meal page**
