### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,4 +1,6 @@
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bemerkenswert/carbotracker/security/code-scanning/2](https://github.com/bemerkenswert/carbotracker/security/code-scanning/2)

The best fix is to add a explicit `permissions` block to the workflow, specifying only the necessary privileges. For deploying to Firebase Hosting with `FirebaseExtended/action-hosting-deploy@v0`, the only required permission is likely `contents: read` in order to fetch the code. No write permissions are required unless something in the deployment step or another step involves creating a status, issue, or PR—which is not evident in the provided workflow. The most secure and compatible change is to add at the workflow root (after `name:` and before `on:`):

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN is only usable for reading repository contents, adhering to the least privilege principle.

Edit the file `.github/workflows/firebase-hosting-merge.yml`, and add the block after `name: Deploy to Firebase Hosting on merge`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
