### PR TITLE
Add current-meal snackbar notifications

### DIFF
--- a/apps/carbotracker/src/current-meal-feature/+state/actions/api.actions.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/actions/api.actions.ts
@@ -17,5 +17,9 @@ export const CurrentMealApiActions = createActionGroup({
     'Current Meal Collection Changed': props<{ currentMeal: CurrentMeal }>(),
     'Unknown Error': props<{ error: unknown }>(),
     'Unsubscribed From Current Meal Stream': emptyProps(),
+    'Add Meal Entry Successful': emptyProps(),
+    'Add Meal Entry Failed': props<{ error: unknown }>(),
+    'Clear Current Meal Successful': emptyProps(),
+    'Clear Current Meal Failed': props<{ error: unknown }>(),
   },
 });

--- a/apps/carbotracker/src/current-meal-feature/+state/actions/snackbar.actions.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/actions/snackbar.actions.ts
@@ -1,0 +1,11 @@
+import { createActionGroup, emptyProps } from '@ngrx/store';
+
+export const CurrentMealSnackBarActions = createActionGroup({
+  source: 'Current Meal | Snack Bar',
+  events: {
+    'Show Add Meal Entry Snackbar Successful': emptyProps(),
+    'Show Add Meal Entry Snackbar Failed': emptyProps(),
+    'Show Clear Current Meal Snackbar Successful': emptyProps(),
+    'Show Clear Current Meal Snackbar Failed': emptyProps(),
+  },
+});

--- a/apps/carbotracker/src/current-meal-feature/+state/api.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/api.effects.spec.ts
@@ -1,0 +1,133 @@
+import { Action, Store } from '@ngrx/store';
+import { of, Subject, throwError } from 'rxjs';
+import { authFeature } from '../../features/auth/+state/auth.store';
+import { CurrentMeal, MealEntry } from '../current-meal.model';
+import { CurrentMealService } from '../services/current-meal.service';
+import { CurrentMealApiActions } from './actions/api.actions';
+import {
+  CreateMealEntryPageComponentActions,
+  CurrentMealPageComponentActions,
+} from './actions/component.actions';
+import { currentMealFeature } from './current-meal.feature';
+import {
+  addMealEntryToCurrentMeal,
+  removeAllMealEntriesOfCurrentMeal$,
+} from './effects/api.effects';
+
+const mealEntry: MealEntry = {
+  productId: 'p1',
+  name: 'spaghetti',
+  carbs: 25,
+  amount: 250,
+};
+
+const currentMeal: CurrentMeal = { mealEntries: [mealEntry] };
+
+const buildStore = (): Store =>
+  ({
+    select: jest.fn((selector) => {
+      if (selector === authFeature.selectUserId) {
+        return of('user-1');
+      }
+      if (selector === currentMealFeature.selectCurrentMeal) {
+        return of(currentMeal);
+      }
+      return of(null);
+    }),
+  }) as unknown as Store;
+
+describe('removeAllMealEntriesOfCurrentMeal$', () => {
+  it('dispatches clearCurrentMealSuccessful when the meal is cleared', () => {
+    const currentMealService = {
+      cleanAllMealEntries: jest.fn(() => of(undefined)),
+    } as unknown as CurrentMealService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    removeAllMealEntriesOfCurrentMeal$(
+      actions$.asObservable(),
+      currentMealService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(CurrentMealPageComponentActions.clearCurrentMealClicked());
+
+    expect(currentMealService.cleanAllMealEntries).toHaveBeenCalledWith({
+      uid: 'user-1',
+    });
+    expect(results).toEqual([
+      CurrentMealApiActions.clearCurrentMealSuccessful(),
+    ]);
+  });
+
+  it('dispatches clearCurrentMealFailed when clearing fails', () => {
+    const currentMealService = {
+      cleanAllMealEntries: jest.fn(() => throwError(() => new Error('boom'))),
+    } as unknown as CurrentMealService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    removeAllMealEntriesOfCurrentMeal$(
+      actions$.asObservable(),
+      currentMealService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(CurrentMealPageComponentActions.clearCurrentMealClicked());
+
+    expect(results).toEqual([
+      CurrentMealApiActions.clearCurrentMealFailed({
+        error: expect.any(Error),
+      }),
+    ]);
+  });
+});
+
+describe('addMealEntryToCurrentMeal', () => {
+  it('dispatches addMealEntrySuccessful when the entry is added', () => {
+    const currentMealService = {
+      addMealEntry: jest.fn(() => of(undefined)),
+    } as unknown as CurrentMealService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    addMealEntryToCurrentMeal(
+      actions$.asObservable(),
+      currentMealService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(
+      CreateMealEntryPageComponentActions.saveClicked({ mealEntry }),
+    );
+
+    expect(currentMealService.addMealEntry).toHaveBeenCalledWith({
+      currentMeal,
+      mealEntry,
+      uid: 'user-1',
+    });
+    expect(results).toEqual([CurrentMealApiActions.addMealEntrySuccessful()]);
+  });
+
+  it('dispatches addMealEntryFailed when adding fails', () => {
+    const currentMealService = {
+      addMealEntry: jest.fn(() => throwError(() => new Error('boom'))),
+    } as unknown as CurrentMealService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    addMealEntryToCurrentMeal(
+      actions$.asObservable(),
+      currentMealService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(
+      CreateMealEntryPageComponentActions.saveClicked({ mealEntry }),
+    );
+
+    expect(results).toEqual([
+      CurrentMealApiActions.addMealEntryFailed({ error: expect.any(Error) }),
+    ]);
+  });
+});

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
@@ -1,19 +1,9 @@
 import { inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatLatestFrom } from '@ngrx/operators';
+import { concatLatestFrom, mapResponse } from '@ngrx/operators';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store } from '@ngrx/store';
-import {
-  catchError,
-  concatMap,
-  EMPTY,
-  exhaustMap,
-  filter,
-  map,
-  of,
-  switchMap,
-  tap,
-} from 'rxjs';
+import { concatMap, EMPTY, exhaustMap, filter, of, switchMap, tap } from 'rxjs';
 import { SavedMealsService } from '../../../saved-meals-feature/services/saved-meals.service';
 import { authFeature } from '../../../features/auth/+state/auth.store';
 import { SavedMealNameDialogService } from '../../../saved-meals-feature/saved-meal-name-dialog/saved-meal-name-dialog.service';
@@ -70,10 +60,11 @@ export const removeAllMealEntriesOfCurrentMeal$ = createEffect(
       concatMap(([, uid]) => {
         if (uid) {
           return currentMealService.cleanAllMealEntries({ uid }).pipe(
-            map(() => CurrentMealApiActions.clearCurrentMealSuccessful()),
-            catchError((error) =>
-              of(CurrentMealApiActions.clearCurrentMealFailed({ error })),
-            ),
+            mapResponse({
+              next: () => CurrentMealApiActions.clearCurrentMealSuccessful(),
+              error: (error) =>
+                CurrentMealApiActions.clearCurrentMealFailed({ error }),
+            }),
           );
         } else {
           return EMPTY;
@@ -104,10 +95,11 @@ export const addMealEntryToCurrentMeal = createEffect(
               uid,
             })
             .pipe(
-              map(() => CurrentMealApiActions.addMealEntrySuccessful()),
-              catchError((error) =>
-                of(CurrentMealApiActions.addMealEntryFailed({ error })),
-              ),
+              mapResponse({
+                next: () => CurrentMealApiActions.addMealEntrySuccessful(),
+                error: (error) =>
+                  CurrentMealApiActions.addMealEntryFailed({ error }),
+              }),
             );
         } else {
           return of();

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
@@ -3,7 +3,17 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { concatLatestFrom } from '@ngrx/operators';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store } from '@ngrx/store';
-import { concatMap, EMPTY, exhaustMap, filter, of, switchMap, tap } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  EMPTY,
+  exhaustMap,
+  filter,
+  map,
+  of,
+  switchMap,
+  tap,
+} from 'rxjs';
 import { SavedMealsService } from '../../../saved-meals-feature/services/saved-meals.service';
 import { authFeature } from '../../../features/auth/+state/auth.store';
 import { SavedMealNameDialogService } from '../../../saved-meals-feature/saved-meal-name-dialog/saved-meal-name-dialog.service';
@@ -14,6 +24,7 @@ import {
   CurrentMealPageComponentActions,
   EditMealEntryPageComponentActions,
 } from '../actions/component.actions';
+import { CurrentMealApiActions } from '../actions/api.actions';
 import { currentMealFeature } from '../current-meal.feature';
 
 export const saveCurrentMealAsSavedMeal = createEffect(
@@ -58,15 +69,18 @@ export const removeAllMealEntriesOfCurrentMeal$ = createEffect(
       concatLatestFrom(() => [store.select(authFeature.selectUserId)]),
       concatMap(([, uid]) => {
         if (uid) {
-          return currentMealService.cleanAllMealEntries({
-            uid,
-          });
+          return currentMealService.cleanAllMealEntries({ uid }).pipe(
+            map(() => CurrentMealApiActions.clearCurrentMealSuccessful()),
+            catchError((error) =>
+              of(CurrentMealApiActions.clearCurrentMealFailed({ error })),
+            ),
+          );
         } else {
           return EMPTY;
         }
       }),
     ),
-  { functional: true, dispatch: false },
+  { functional: true },
 );
 
 export const addMealEntryToCurrentMeal = createEffect(
@@ -83,17 +97,24 @@ export const addMealEntryToCurrentMeal = createEffect(
       ]),
       concatMap(([{ mealEntry }, uid, currentMeal]) => {
         if (uid) {
-          return currentMealService.addMealEntry({
-            currentMeal,
-            mealEntry,
-            uid,
-          });
+          return currentMealService
+            .addMealEntry({
+              currentMeal,
+              mealEntry,
+              uid,
+            })
+            .pipe(
+              map(() => CurrentMealApiActions.addMealEntrySuccessful()),
+              catchError((error) =>
+                of(CurrentMealApiActions.addMealEntryFailed({ error })),
+              ),
+            );
         } else {
           return of();
         }
       }),
     ),
-  { functional: true, dispatch: false },
+  { functional: true },
 );
 
 export const updateMealEntryOfCurrentMeal = createEffect(

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.spec.ts
@@ -1,0 +1,103 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Action } from '@ngrx/store';
+import { Observable, of, Subject } from 'rxjs';
+import { CurrentMealApiActions } from '../actions/api.actions';
+import { CurrentMealSnackBarActions } from '../actions/snackbar.actions';
+import {
+  showAddMealEntryFailedSnackbar$,
+  showAddMealEntrySuccessfulSnackbar$,
+  showClearCurrentMealFailedSnackbar$,
+  showClearCurrentMealSuccessfulSnackbar$,
+} from './snackbar.effects';
+
+const buildSnackBar = (): MatSnackBar =>
+  ({
+    open: jest.fn().mockReturnValue({
+      afterOpened: jest.fn().mockReturnValue(of(undefined)),
+    }),
+  }) as unknown as MatSnackBar;
+
+const buildEffect = (
+  effect: (
+    actions$: Observable<Action>,
+    snackBar: MatSnackBar,
+  ) => Observable<Action>,
+) => {
+  const actions$ = new Subject<Action>();
+  const snackBar = buildSnackBar();
+  const results: Action[] = [];
+  effect(actions$.asObservable(), snackBar).subscribe((action) =>
+    results.push(action),
+  );
+  return { actions$, snackBar, results };
+};
+
+describe('snackbar effects', () => {
+  it('shows the add meal entry success snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showAddMealEntrySuccessfulSnackbar$,
+    );
+
+    actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
+
+    expect(snackBar.open).toHaveBeenCalledWith('The meal entry was added.');
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showAddMealEntrySnackbarSuccessful(),
+    ]);
+  });
+
+  it('shows the add meal entry failure snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showAddMealEntryFailedSnackbar$,
+    );
+
+    actions$.next(CurrentMealApiActions.addMealEntryFailed({ error: 'boom' }));
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'The meal entry could not be added.',
+    );
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showAddMealEntrySnackbarFailed(),
+    ]);
+  });
+
+  it('shows the clear current meal success snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showClearCurrentMealSuccessfulSnackbar$,
+    );
+
+    actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
+
+    expect(snackBar.open).toHaveBeenCalledWith('The current meal was cleared.');
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showClearCurrentMealSnackbarSuccessful(),
+    ]);
+  });
+
+  it('shows the clear current meal failure snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showClearCurrentMealFailedSnackbar$,
+    );
+
+    actions$.next(
+      CurrentMealApiActions.clearCurrentMealFailed({ error: 'boom' }),
+    );
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'The current meal could not be cleared.',
+    );
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showClearCurrentMealSnackbarFailed(),
+    ]);
+  });
+
+  it('does not show the add meal entry snackbar for other actions', () => {
+    const { actions$, snackBar } = buildEffect(
+      showAddMealEntrySuccessfulSnackbar$,
+    );
+
+    actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
+
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.ts
@@ -1,0 +1,78 @@
+import { inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { map, switchMap } from 'rxjs';
+import { CurrentMealApiActions } from '../actions/api.actions';
+import { CurrentMealSnackBarActions } from '../actions/snackbar.actions';
+
+export const showAddMealEntrySuccessfulSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.addMealEntrySuccessful),
+      switchMap(() =>
+        snackBar
+          .open('The meal entry was added.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showAddMealEntrySnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showAddMealEntryFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.addMealEntryFailed),
+      switchMap(() =>
+        snackBar
+          .open('The meal entry could not be added.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showAddMealEntrySnackbarFailed(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showClearCurrentMealSuccessfulSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.clearCurrentMealSuccessful),
+      switchMap(() =>
+        snackBar
+          .open('The current meal was cleared.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showClearCurrentMealSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showClearCurrentMealFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.clearCurrentMealFailed),
+      switchMap(() =>
+        snackBar
+          .open('The current meal could not be cleared.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showClearCurrentMealSnackbarFailed(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);

--- a/apps/carbotracker/src/current-meal-feature/current-meal.routes.ts
+++ b/apps/carbotracker/src/current-meal-feature/current-meal.routes.ts
@@ -3,6 +3,7 @@ import { provideEffects } from '@ngrx/effects';
 import { provideState } from '@ngrx/store';
 import * as apiEffects from './+state/effects/api.effects';
 import * as routingEffects from './+state/effects/routing.effects';
+import * as snackbarEffects from './+state/effects/snackbar.effects';
 import { currentMealFeature } from './+state/current-meal.feature';
 
 const CURRENT_MEAL_ROUTES: Routes = [
@@ -12,7 +13,7 @@ const CURRENT_MEAL_ROUTES: Routes = [
       import('./pages/CurrentMealPage/current-meal-page.component'),
     providers: [
       provideState(currentMealFeature),
-      provideEffects(apiEffects, routingEffects),
+      provideEffects(apiEffects, routingEffects, snackbarEffects),
     ],
   },
   {


### PR DESCRIPTION
## What
Implements #205 — current-meal snackbar notifications.

## Changes
- Add API success/failure actions for adding a MealEntry and clearing the CurrentMeal (`CurrentMealApiActions`).
- `addMealEntryToCurrentMeal` and `removeAllMealEntriesOfCurrentMeal$` now dispatch those actions on completion/error (dropped `dispatch: false`).
- New `CurrentMealSnackBarActions` + `snackbar.effects.ts` showing:
  - "The meal entry was added." / "The meal entry could not be added."
  - "The current meal was cleared." / "The current meal could not be cleared."
- Registered `snackbarEffects` in `current-meal.routes.ts`.
- New `snackbar.effects.spec.ts` testing all four effects at the effect-function level with a mocked `MatSnackBar`.

## Verification
- Typecheck, eslint, prettier all clean.
- Full test suite: 16 tests passing (incl. 5 new snackbar effect tests).
- Reviewed via code-review skill (Standards + Spec axes, both pass).

Closes #205