### PR TITLE
Settings insulin-to-carb ratios snackbar

### DIFF
--- a/apps/carbotracker/src/features/settings/+state/actions/snackbar.actions.ts
+++ b/apps/carbotracker/src/features/settings/+state/actions/snackbar.actions.ts
@@ -14,3 +14,12 @@ export const ChangePasswordPageSnackBarActions = createActionGroup({
     'Show Old Password Was Wrong Snackbar Successful': emptyProps(),
   },
 });
+
+export const InsulinToCarbRatiosPageSnackBarActions = createActionGroup({
+  source: 'Settings | Insulin To Carb Ratios Page Snack Bar',
+  events: {
+    'Show Insulin To Carb Ratios Updated Snackbar Successful': emptyProps(),
+    'Show Insulin To Carb Ratios Update Failed Snackbar Successful':
+      emptyProps(),
+  },
+});

--- a/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
@@ -1,0 +1,67 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Action } from '@ngrx/store';
+import { Observable, of, Subject } from 'rxjs';
+import { SettingsApiActions } from '../actions/api.actions';
+import { InsulinToCarbRatiosPageSnackBarActions } from '../actions/snackbar.actions';
+import {
+  showInsulinToCarbRatiosUpdateFailedSnackbar$,
+  showInsulinToCarbRatiosWereUpdatedSnackbar$,
+} from './snackbar.effects';
+
+jest.mock('firebase/auth', () => ({}));
+
+const buildSnackBar = (): jest.Mocked<MatSnackBar> =>
+  ({
+    open: jest.fn(() => ({
+      afterOpened: () => of(undefined),
+    })),
+  }) as unknown as jest.Mocked<MatSnackBar>;
+
+const collectEffectOutput = (
+  effect: (
+    actions$: Observable<Action>,
+    snackBar: MatSnackBar,
+  ) => Observable<Action>,
+) => {
+  const snackBar = buildSnackBar();
+  const actions$ = new Subject<Action>();
+  const emitted: Action[] = [];
+  effect(actions$.asObservable(), snackBar).subscribe((action) =>
+    emitted.push(action),
+  );
+  return { snackBar, actions$, emitted };
+};
+
+describe('showInsulinToCarbRatiosWereUpdatedSnackbar$', () => {
+  it('shows the success snackbar and dispatches the follow-up action when the ratios were updated', () => {
+    const { snackBar, actions$, emitted } = collectEffectOutput(
+      showInsulinToCarbRatiosWereUpdatedSnackbar$,
+    );
+
+    actions$.next(SettingsApiActions.settingInsulinToCarbRatiosSuccessful());
+
+    expect(snackBar.open).toHaveBeenCalledWith('Your ratios were updated.');
+    expect(emitted).toEqual([
+      InsulinToCarbRatiosPageSnackBarActions.showInsulinToCarbRatiosUpdatedSnackbarSuccessful(),
+    ]);
+  });
+});
+
+describe('showInsulinToCarbRatiosUpdateFailedSnackbar$', () => {
+  it('shows the failure snackbar and dispatches the follow-up action when updating the ratios fails', () => {
+    const { snackBar, actions$, emitted } = collectEffectOutput(
+      showInsulinToCarbRatiosUpdateFailedSnackbar$,
+    );
+
+    actions$.next(
+      SettingsApiActions.settingInsulinToCarbRatiosFailed({ error: 'nope' }),
+    );
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Your ratios could not be updated.',
+    );
+    expect(emitted).toEqual([
+      InsulinToCarbRatiosPageSnackBarActions.showInsulinToCarbRatiosUpdateFailedSnackbarSuccessful(),
+    ]);
+  });
+});

--- a/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.ts
@@ -7,9 +7,11 @@ import {
   LoginApiActions,
   PasswordApiActions,
 } from '../../../auth/+state';
+import { SettingsApiActions } from '../actions/api.actions';
 import {
   AccountPageSnackBarActions,
   ChangePasswordPageSnackBarActions,
+  InsulinToCarbRatiosPageSnackBarActions,
 } from '../actions/snackbar.actions';
 
 export const showEmailAlreadyExistsSnackBar$ = createEffect(
@@ -60,6 +62,42 @@ export const showOldPasswordWasWrongSnackbar$ = createEffect(
           .pipe(
             map(() =>
               ChangePasswordPageSnackBarActions.showOldPasswordWasWrongSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showInsulinToCarbRatiosWereUpdatedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(SettingsApiActions.settingInsulinToCarbRatiosSuccessful),
+      switchMap(() =>
+        snackBar
+          .open('Your ratios were updated.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              InsulinToCarbRatiosPageSnackBarActions.showInsulinToCarbRatiosUpdatedSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showInsulinToCarbRatiosUpdateFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(SettingsApiActions.settingInsulinToCarbRatiosFailed),
+      switchMap(() =>
+        snackBar
+          .open('Your ratios could not be updated.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              InsulinToCarbRatiosPageSnackBarActions.showInsulinToCarbRatiosUpdateFailedSnackbarSuccessful(),
             ),
           ),
       ),


### PR DESCRIPTION
Closes #204

## What

Shows a snackbar when the user saves insulin-to-carb ratios in settings: success ("Your ratios were updated.") and failure ("Your ratios could not be updated."). Extends the existing settings snackbar actions and effects; the API layer already dispatches the success/failure actions via `mapResponse`.

## Changes

- `snackbar.effects.ts`: two new effects listening on `SettingsApiActions.settingInsulinToCarbRatiosSuccessful` / `...Failed`
- `snackbar.actions.ts`: new `InsulinToCarbRatiosPageSnackBarActions` handoff group
- `snackbar.effects.spec.ts`: effect-level tests with mocked `MatSnackBar`, asserting both the snackbar message and the emitted handoff action

## Notes

The spec mocks the `firebase/auth` system boundary so the effect module can be imported without loading the auth barrel's transitive Firebase SDK into the Node test environment.

## Verification

- Typecheck (app + spec tsconfigs) passes
- Full jest suite: 5 suites / 13 tests pass
- Lint and prettier pass