### PR TITLE
Add snackbar notifications for all product CRUD operations (#203)

### DIFF
--- a/apps/carbotracker/src/products-feature/+state/actions/snackbar.actions.ts
+++ b/apps/carbotracker/src/products-feature/+state/actions/snackbar.actions.ts
@@ -1,8 +1,25 @@
 import { createActionGroup, emptyProps } from '@ngrx/store';
 
+export const CreateProductPageSnackBarActions = createActionGroup({
+  source: 'Products | Create Product Page Snack Bar',
+  events: {
+    'Show Create Product Snackbar Successful': emptyProps(),
+    'Show Create Product Snackbar Failure': emptyProps(),
+  },
+});
+
 export const EditProductPageSnackBarActions = createActionGroup({
   source: 'Products | Edit Product Page Snack Bar',
   events: {
     'Show Edit Product Snackbar Successful': emptyProps(),
+    'Show Edit Product Snackbar Failure': emptyProps(),
+  },
+});
+
+export const DeleteProductSnackBarActions = createActionGroup({
+  source: 'Products | Delete Product Snack Bar',
+  events: {
+    'Show Delete Product Snackbar Successful': emptyProps(),
+    'Show Delete Product Snackbar Failure': emptyProps(),
   },
 });

--- a/apps/carbotracker/src/products-feature/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/products-feature/+state/effects/snackbar.effects.spec.ts
@@ -1,0 +1,129 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Action } from '@ngrx/store';
+import { of, Subject } from 'rxjs';
+import { ProductsApiActions } from '../actions/api.actions';
+import {
+  showCreateProductFailedSnackbar$,
+  showDeleteProductFailedSnackbar$,
+  showProductWasChangedSnackbar$,
+  showProductWasCreatedSnackbar$,
+  showProductWasDeletedSnackbar$,
+  showUpdateProductFailedSnackbar$,
+} from './snackbar.effects';
+
+describe('snackbar effects', () => {
+  const buildSnackBar = (): jest.Mocked<MatSnackBar> => {
+    const afterOpened = jest.fn(() => of(void 0));
+    return {
+      open: jest.fn(() => ({ afterOpened })),
+    } as unknown as jest.Mocked<MatSnackBar>;
+  };
+
+  describe('showProductWasCreatedSnackbar$', () => {
+    it('shows a success snackbar when product is created', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showProductWasCreatedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(ProductsApiActions.creatingProductSuccessful());
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product was added successfully.',
+      );
+    });
+  });
+
+  describe('showCreateProductFailedSnackbar$', () => {
+    it('shows a failure snackbar when product creation fails', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showCreateProductFailedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(
+        ProductsApiActions.creatingProductFailed({ error: 'error' }),
+      );
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product could not be added.',
+      );
+    });
+  });
+
+  describe('showProductWasChangedSnackbar$', () => {
+    it('shows a success snackbar when product is updated', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showProductWasChangedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(ProductsApiActions.updatingProductSuccessful());
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product was updated successfully.',
+      );
+    });
+  });
+
+  describe('showUpdateProductFailedSnackbar$', () => {
+    it('shows a failure snackbar when product update fails', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showUpdateProductFailedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(
+        ProductsApiActions.updatingProductFailed({ error: 'error' }),
+      );
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product could not be updated.',
+      );
+    });
+  });
+
+  describe('showProductWasDeletedSnackbar$', () => {
+    it('shows a success snackbar when product is deleted', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showProductWasDeletedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(ProductsApiActions.deletingProductSuccessful());
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product was deleted successfully.',
+      );
+    });
+  });
+
+  describe('showDeleteProductFailedSnackbar$', () => {
+    it('shows a failure snackbar when product deletion fails', () => {
+      const actions$ = new Subject<Action>();
+      const snackBar = buildSnackBar();
+      showDeleteProductFailedSnackbar$(
+        actions$.asObservable(),
+        snackBar,
+      ).subscribe();
+
+      actions$.next(
+        ProductsApiActions.deletingProductFailed({ error: 'error' }),
+      );
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The product could not be deleted.',
+      );
+    });
+  });
+});

--- a/apps/carbotracker/src/products-feature/+state/effects/snackbar.effects.ts
+++ b/apps/carbotracker/src/products-feature/+state/effects/snackbar.effects.ts
@@ -3,7 +3,47 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { map, switchMap } from 'rxjs';
 import { ProductsApiActions } from '../actions/api.actions';
-import { EditProductPageSnackBarActions } from '../actions/snackbar.actions';
+import {
+  CreateProductPageSnackBarActions,
+  DeleteProductSnackBarActions,
+  EditProductPageSnackBarActions,
+} from '../actions/snackbar.actions';
+
+export const showProductWasCreatedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(ProductsApiActions.creatingProductSuccessful),
+      switchMap(() =>
+        snackBar
+          .open('The product was added successfully.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CreateProductPageSnackBarActions.showCreateProductSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { dispatch: true, functional: true },
+);
+
+export const showCreateProductFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(ProductsApiActions.creatingProductFailed),
+      switchMap(() =>
+        snackBar
+          .open('The product could not be added.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CreateProductPageSnackBarActions.showCreateProductSnackbarFailure(),
+            ),
+          ),
+      ),
+    ),
+  { dispatch: true, functional: true },
+);
 
 export const showProductWasChangedSnackbar$ = createEffect(
   (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
@@ -16,6 +56,60 @@ export const showProductWasChangedSnackbar$ = createEffect(
           .pipe(
             map(() =>
               EditProductPageSnackBarActions.showEditProductSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { dispatch: true, functional: true },
+);
+
+export const showUpdateProductFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(ProductsApiActions.updatingProductFailed),
+      switchMap(() =>
+        snackBar
+          .open('The product could not be updated.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              EditProductPageSnackBarActions.showEditProductSnackbarFailure(),
+            ),
+          ),
+      ),
+    ),
+  { dispatch: true, functional: true },
+);
+
+export const showProductWasDeletedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(ProductsApiActions.deletingProductSuccessful),
+      switchMap(() =>
+        snackBar
+          .open('The product was deleted successfully.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              DeleteProductSnackBarActions.showDeleteProductSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { dispatch: true, functional: true },
+);
+
+export const showDeleteProductFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(ProductsApiActions.deletingProductFailed),
+      switchMap(() =>
+        snackBar
+          .open('The product could not be deleted.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              DeleteProductSnackBarActions.showDeleteProductSnackbarFailure(),
             ),
           ),
       ),


### PR DESCRIPTION
Closes #203

## What

Adds snackbar notifications for all Product CRUD operations: add, edit, and delete (both success and failure paths).

The API layer already dispatches success and failure actions for all three operations — this PR adds the effects to react to them with MatSnackBar messages.

## Changes

- **Action groups**: `CreateProductPageSnackBarActions`, `EditProductPageSnackBarActions`, `DeleteProductSnackBarActions` — each with success and failure events
- **Effects**: 6 new functional effects (create/edit/delete x success/failure) in `snackbar.effects.ts`
- **Tests**: 6 tests in `snackbar.effects.spec.ts` at the effect-function level with mocked `MatSnackBar`

## Acceptance criteria

- [x] Adding a Product shows success snackbar ("The product was added successfully.")
- [x] Adding a Product that fails shows failure snackbar ("The product could not be added.")
- [x] Editing a Product that succeeds shows "The product was updated successfully." (already existed)
- [x] Editing a Product that fails shows failure snackbar ("The product could not be updated.")
- [x] Deleting a Product shows success snackbar ("The product was deleted successfully.")
- [x] Deleting a Product that fails shows failure snackbar ("The product could not be deleted.")
- [x] Snackbar effects tested at effect-function level with mocked MatSnackBar
