### PR TITLE
Show snackbar when a meal is saved (#189)

### DIFF
--- a/apps/carbotracker/src/current-meal-feature/+state/actions/api.actions.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/actions/api.actions.ts
@@ -21,5 +21,7 @@ export const CurrentMealApiActions = createActionGroup({
     'Add Meal Entry Failed': props<{ error: unknown }>(),
     'Clear Current Meal Successful': emptyProps(),
     'Clear Current Meal Failed': props<{ error: unknown }>(),
+    'Save Current Meal Successful': emptyProps(),
+    'Save Current Meal Failed': props<{ error: unknown }>(),
   },
 });

--- a/apps/carbotracker/src/current-meal-feature/+state/actions/snackbar.actions.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/actions/snackbar.actions.ts
@@ -7,5 +7,7 @@ export const CurrentMealSnackBarActions = createActionGroup({
     'Show Add Meal Entry Snackbar Failed': emptyProps(),
     'Show Clear Current Meal Snackbar Successful': emptyProps(),
     'Show Clear Current Meal Snackbar Failed': emptyProps(),
+    'Show Save Current Meal Snackbar Successful': emptyProps(),
+    'Show Save Current Meal Snackbar Failed': emptyProps(),
   },
 });

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
@@ -40,12 +40,18 @@ export const saveCurrentMealAsSavedMeal = createEffect(
               !result.cancelled,
           ),
           exhaustMap(({ name }) =>
-            savedMealsService.saveCurrentMeal({ uid, currentMeal, name }),
+            savedMealsService.saveCurrentMeal({ uid, currentMeal, name }).pipe(
+              mapResponse({
+                next: () => CurrentMealApiActions.saveCurrentMealSuccessful(),
+                error: (error) =>
+                  CurrentMealApiActions.saveCurrentMealFailed({ error }),
+              }),
+            ),
           ),
         );
       }),
     ),
-  { dispatch: false, functional: true },
+  { functional: true },
 );
 
 export const removeAllMealEntriesOfCurrentMeal$ = createEffect(

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.spec.ts
@@ -8,6 +8,8 @@ import {
   showAddMealEntrySuccessfulSnackbar$,
   showClearCurrentMealFailedSnackbar$,
   showClearCurrentMealSuccessfulSnackbar$,
+  showSaveCurrentMealFailedSnackbar$,
+  showSaveCurrentMealSuccessfulSnackbar$,
 } from './snackbar.effects';
 
 const buildSnackBar = (): MatSnackBar =>
@@ -99,5 +101,33 @@ describe('snackbar effects', () => {
     actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
 
     expect(snackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('shows the save current meal success snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showSaveCurrentMealSuccessfulSnackbar$,
+    );
+
+    actions$.next(CurrentMealApiActions.saveCurrentMealSuccessful());
+
+    expect(snackBar.open).toHaveBeenCalledWith('The meal was saved.');
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showSaveCurrentMealSnackbarSuccessful(),
+    ]);
+  });
+
+  it('shows the save current meal failure snackbar', () => {
+    const { actions$, snackBar, results } = buildEffect(
+      showSaveCurrentMealFailedSnackbar$,
+    );
+
+    actions$.next(
+      CurrentMealApiActions.saveCurrentMealFailed({ error: 'boom' }),
+    );
+
+    expect(snackBar.open).toHaveBeenCalledWith('The meal could not be saved.');
+    expect(results).toEqual([
+      CurrentMealSnackBarActions.showSaveCurrentMealSnackbarFailed(),
+    ]);
   });
 });

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/snackbar.effects.ts
@@ -76,3 +76,39 @@ export const showClearCurrentMealFailedSnackbar$ = createEffect(
     ),
   { functional: true },
 );
+
+export const showSaveCurrentMealSuccessfulSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.saveCurrentMealSuccessful),
+      switchMap(() =>
+        snackBar
+          .open('The meal was saved.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showSaveCurrentMealSnackbarSuccessful(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);
+
+export const showSaveCurrentMealFailedSnackbar$ = createEffect(
+  (actions$ = inject(Actions), snackBar = inject(MatSnackBar)) =>
+    actions$.pipe(
+      ofType(CurrentMealApiActions.saveCurrentMealFailed),
+      switchMap(() =>
+        snackBar
+          .open('The meal could not be saved.')
+          .afterOpened()
+          .pipe(
+            map(() =>
+              CurrentMealSnackBarActions.showSaveCurrentMealSnackbarFailed(),
+            ),
+          ),
+      ),
+    ),
+  { functional: true },
+);

--- a/apps/carbotracker/src/current-meal-feature/+state/save-current-meal.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/save-current-meal.effects.spec.ts
@@ -1,9 +1,10 @@
 import { Action, Store } from '@ngrx/store';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { authFeature } from '../../features/auth/+state/auth.store';
 import { SavedMealNameDialogService } from '../../saved-meals-feature/saved-meal-name-dialog/saved-meal-name-dialog.service';
 import { SavedMealsService } from '../../saved-meals-feature/services/saved-meals.service';
 import { CurrentMeal } from '../current-meal.model';
+import { CurrentMealApiActions } from './actions/api.actions';
 import { CurrentMealPageComponentActions } from './actions/component.actions';
 import { saveCurrentMealAsSavedMeal } from './effects/api.effects';
 import { currentMealFeature } from './current-meal.feature';
@@ -31,7 +32,7 @@ describe('saveCurrentMealAsSavedMeal', () => {
   const buildMocks = () => {
     const savedMealsService = {
       saveCurrentMeal: jest.fn(() => of(undefined)),
-    } as unknown as SavedMealsService;
+    } as unknown as jest.Mocked<SavedMealsService>;
     const nameDialogService = {
       open: jest.fn(),
     } as unknown as jest.Mocked<SavedMealNameDialogService>;
@@ -46,13 +47,13 @@ describe('saveCurrentMealAsSavedMeal', () => {
 
     const actions$ = new Subject<Action>();
     const store = buildStore();
-    const effect$ = saveCurrentMealAsSavedMeal(
+    const results: Action[] = [];
+    saveCurrentMealAsSavedMeal(
       actions$.asObservable(),
       store,
       savedMealsService,
       nameDialogService,
-    );
-    effect$.subscribe();
+    ).subscribe((action) => results.push(action));
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
 
@@ -62,6 +63,9 @@ describe('saveCurrentMealAsSavedMeal', () => {
       currentMeal,
       name: 'Steffens Pasta Dream',
     });
+    expect(results).toEqual([
+      CurrentMealApiActions.saveCurrentMealSuccessful(),
+    ]);
   });
 
   it('does not save when the user cancels the dialog', () => {
@@ -70,17 +74,42 @@ describe('saveCurrentMealAsSavedMeal', () => {
 
     const actions$ = new Subject<Action>();
     const store = buildStore();
-    const effect$ = saveCurrentMealAsSavedMeal(
+    saveCurrentMealAsSavedMeal(
       actions$.asObservable(),
       store,
       savedMealsService,
       nameDialogService,
-    );
-    effect$.subscribe();
+    ).subscribe();
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
 
     expect(nameDialogService.open).toHaveBeenCalled();
     expect(savedMealsService.saveCurrentMeal).not.toHaveBeenCalled();
+  });
+
+  it('dispatches saveCurrentMealFailed when saving fails', () => {
+    const { savedMealsService, nameDialogService } = buildMocks();
+    nameDialogService.open.mockReturnValue(
+      of({ cancelled: false, name: 'Steffens Pasta Dream' }),
+    );
+    savedMealsService.saveCurrentMeal.mockReturnValue(
+      throwError(() => new Error('boom')),
+    );
+
+    const actions$ = new Subject<Action>();
+    const store = buildStore();
+    const results: Action[] = [];
+    saveCurrentMealAsSavedMeal(
+      actions$.asObservable(),
+      store,
+      savedMealsService,
+      nameDialogService,
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
+
+    expect(results).toEqual([
+      CurrentMealApiActions.saveCurrentMealFailed({ error: expect.any(Error) }),
+    ]);
   });
 });


### PR DESCRIPTION
Closes #189

## What
When the user saves the current meal as a saved meal, show confirmation feedback via a snackbar, matching the established snackbar work on product create/update (#209) and current-meal actions (#206).

## Changes
- Add `SaveCurrentMealSuccessful` / `SaveCurrentMealFailed` API actions (`CurrentMealApiActions`).
- `saveCurrentMealAsSavedMeal` now dispatches those actions on completion/error (dropped `dispatch: false`, using `mapResponse`).
- New `CurrentMealSnackBarActions` events + two snackbar effects showing:
  - "The meal was saved." / "The meal could not be saved."
- Registered automatically via namespace import in `current-meal.routes.ts`.
- Tests: save-meal effect dispatches success/failure at the effect-function level; snackbar effects tested with mocked `MatSnackBar`.

## Verification
- Typecheck, eslint, prettier clean.
- Full test suite: 31 tests passing (3 new).
- Reviewed via code-review skill (Standards + Spec axes, both pass).