### PR TITLE
Move page logic out of components into selectors (#188)

### DIFF
--- a/apps/carbotracker/src/current-meal-feature/+state/actions/component.actions.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/actions/component.actions.ts
@@ -1,4 +1,5 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import { Product } from '../../../products-feature/product.model';
 import { MealEntry } from '../../current-meal.model';
 
 export const CurrentMealPageComponentActions = createActionGroup({
@@ -17,7 +18,7 @@ export const CreateMealEntryPageComponentActions = createActionGroup({
   source: 'Current Meal | Create Meal Entry Page Component',
   events: {
     'Entered Create Meal Entry Page': emptyProps(),
-    'Save Clicked': props<{ mealEntry: MealEntry }>(),
+    'Save Clicked': props<{ product: Product; amount: number }>(),
     'Product Search Term Changed': props<{ productSearchTerm: string }>(),
   },
 });

--- a/apps/carbotracker/src/current-meal-feature/+state/api.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/api.effects.spec.ts
@@ -21,6 +21,13 @@ const mealEntry: MealEntry = {
   amount: 250,
 };
 
+const product = {
+  id: 'p1',
+  name: 'spaghetti',
+  creator: 'user-a',
+  carbs: 25,
+};
+
 const currentMeal: CurrentMeal = { mealEntries: [mealEntry] };
 
 const buildStore = (): Store =>
@@ -98,7 +105,10 @@ describe('addMealEntryToCurrentMeal', () => {
     ).subscribe((action) => results.push(action));
 
     actions$.next(
-      CreateMealEntryPageComponentActions.saveClicked({ mealEntry }),
+      CreateMealEntryPageComponentActions.saveClicked({
+        product,
+        amount: 250,
+      }),
     );
 
     expect(currentMealService.addMealEntry).toHaveBeenCalledWith({
@@ -123,7 +133,10 @@ describe('addMealEntryToCurrentMeal', () => {
     ).subscribe((action) => results.push(action));
 
     actions$.next(
-      CreateMealEntryPageComponentActions.saveClicked({ mealEntry }),
+      CreateMealEntryPageComponentActions.saveClicked({
+        product,
+        amount: 250,
+      }),
     );
 
     expect(results).toEqual([

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/api.effects.ts
@@ -86,8 +86,14 @@ export const addMealEntryToCurrentMeal = createEffect(
         store.select(authFeature.selectUserId),
         store.select(currentMealFeature.selectCurrentMeal),
       ]),
-      concatMap(([{ mealEntry }, uid, currentMeal]) => {
+      concatMap(([{ product, amount }, uid, currentMeal]) => {
         if (uid) {
+          const mealEntry = {
+            productId: product.id,
+            name: product.name,
+            carbs: product.carbs,
+            amount,
+          };
           return currentMealService
             .addMealEntry({
               currentMeal,

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/routing.effects.spec.ts
@@ -1,0 +1,59 @@
+import { Action } from '@ngrx/store';
+import { Router } from '@angular/router';
+import { Subject, of } from 'rxjs';
+import { CurrentMealApiActions } from '../actions/api.actions';
+import {
+  EditMealEntryPageComponentActions,
+  CreateMealEntryPageComponentActions,
+} from '../actions/component.actions';
+import { navigateToCurrentMeal$ } from './routing.effects';
+
+const buildRouter = (): Router =>
+  ({
+    navigate: jest.fn(() => of(true)),
+  }) as unknown as Router;
+
+describe('navigateToCurrentMeal$', () => {
+  it('navigates to the current meal page after a meal entry is added successfully', () => {
+    const router = buildRouter();
+    const actions$ = new Subject<Action>();
+
+    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe();
+
+    actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
+
+    expect(router.navigate).toHaveBeenCalledWith(['app', 'current-meal']);
+  });
+
+  it('does not navigate on the create meal entry page save click', () => {
+    const router = buildRouter();
+    const actions$ = new Subject<Action>();
+
+    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe();
+
+    actions$.next(
+      CreateMealEntryPageComponentActions.saveClicked({
+        product: {
+          id: 'p1',
+          name: 'spaghetti',
+          creator: 'user-a',
+          carbs: 25,
+        },
+        amount: 250,
+      }),
+    );
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the current meal page on edit meal entry page actions', () => {
+    const router = buildRouter();
+    const actions$ = new Subject<Action>();
+
+    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe();
+
+    actions$.next(EditMealEntryPageComponentActions.goBackIconClicked());
+
+    expect(router.navigate).toHaveBeenCalledWith(['app', 'current-meal']);
+  });
+});

--- a/apps/carbotracker/src/current-meal-feature/+state/effects/routing.effects.ts
+++ b/apps/carbotracker/src/current-meal-feature/+state/effects/routing.effects.ts
@@ -2,8 +2,8 @@ import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { exhaustMap, from } from 'rxjs';
+import { CurrentMealApiActions } from '../actions/api.actions';
 import {
-  CreateMealEntryPageComponentActions,
   CurrentMealPageComponentActions,
   EditMealEntryPageComponentActions,
 } from '../actions/component.actions';
@@ -23,7 +23,7 @@ export const navigateToCurrentMeal$ = createEffect(
   (actions$ = inject(Actions), router = inject(Router)) =>
     actions$.pipe(
       ofType(
-        CreateMealEntryPageComponentActions.saveClicked,
+        CurrentMealApiActions.addMealEntrySuccessful,
         EditMealEntryPageComponentActions.saveClicked,
         EditMealEntryPageComponentActions.deleteMealEntryClicked,
         EditMealEntryPageComponentActions.goBackIconClicked,

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
@@ -1,11 +1,7 @@
 <form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
   <mat-form-field>
     <mat-label>Amount</mat-label>
-    <input
-      [formControl]="formGroup.controls.amount"
-      type="number"
-      matInput
-    />
+    <input [formControl]="formGroup.controls.amount" type="number" matInput />
   </mat-form-field>
   <mat-form-field>
     <mat-label>Product</mat-label>

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
@@ -1,12 +1,9 @@
-<form #productForm="ngForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
   <mat-form-field>
     <mat-label>Amount</mat-label>
     <input
-      name="amount"
-      required
-      min="1"
+      formControlName="amount"
       type="number"
-      [(ngModel)]="model.amount"
       matInput
     />
   </mat-form-field>
@@ -14,19 +11,17 @@
     <mat-label>Product</mat-label>
     <input
       placeholder="Select Product"
-      name="product"
-      required
+      formControlName="product"
       type="text"
       matInput
       (input)="onFilterChange($event)"
-      [(ngModel)]="model.product"
       [matAutocomplete]="productAutoComplete"
     />
     <mat-autocomplete
       #productAutoComplete="matAutocomplete"
       [displayWith]="displayProduct"
     >
-      @for (product of filteredProducts(); track product.id) {
+      @for (product of viewModel().availableProducts; track product.id) {
         <mat-option [value]="product">
           {{ product.name }} {{ product.carbs }}g
         </mat-option>
@@ -36,7 +31,7 @@
   <button
     color="primary"
     type="submit"
-    [disabled]="productForm.invalid || productForm.pristine"
+    [disabled]="formGroup.invalid || formGroup.pristine"
     mat-fab
     ctuiFixedPosition
     matTooltip="Save meal entry"

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.html
@@ -2,7 +2,7 @@
   <mat-form-field>
     <mat-label>Amount</mat-label>
     <input
-      formControlName="amount"
+      [formControl]="formGroup.controls.amount"
       type="number"
       matInput
     />
@@ -11,7 +11,7 @@
     <mat-label>Product</mat-label>
     <input
       placeholder="Select Product"
-      formControlName="product"
+      [formControl]="formGroup.controls.product"
       type="text"
       matInput
       (input)="onFilterChange($event)"

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.ts
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.component.ts
@@ -4,7 +4,12 @@ import {
   inject,
   OnInit,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -15,18 +20,18 @@ import { CtuiFixedPositionDirective } from '@carbotracker/ui';
 import { Store } from '@ngrx/store';
 import { CreateMealEntryPageComponentActions as ComponentActions } from '../../+state/actions/component.actions';
 import { Product } from '../../../products-feature/product.model';
-import { selectFilteredProducts } from './create-meal-entry-page.selectors';
+import { selectCreateMealEntryPageViewModel } from './create-meal-entry-page.selectors';
 
-type FormModel = {
-  amount: number | null;
-  product: Product | null;
-};
+interface CreateMealEntryFormControls {
+  amount: FormControl<number | null>;
+  product: FormControl<Product | null>;
+}
 
 @Component({
   selector: 'carbotracker-create-meal-entry-page',
   imports: [
     CtuiFixedPositionDirective,
-    FormsModule,
+    ReactiveFormsModule,
     MatAutocompleteModule,
     MatButtonModule,
     MatFormFieldModule,
@@ -40,13 +45,18 @@ type FormModel = {
 })
 export default class CreateMealEntryPageComponent implements OnInit {
   private readonly store = inject(Store);
-  protected readonly filteredProducts = this.store.selectSignal(
-    selectFilteredProducts,
+  protected readonly viewModel = this.store.selectSignal(
+    selectCreateMealEntryPageViewModel,
   );
-  public readonly model: FormModel = {
-    amount: null,
-    product: null,
-  };
+
+  protected readonly formGroup = new FormGroup<CreateMealEntryFormControls>({
+    amount: new FormControl(null, {
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    product: new FormControl<Product | null>(null, {
+      validators: [Validators.required],
+    }),
+  });
 
   public ngOnInit(): void {
     this.store.dispatch(ComponentActions.enteredCreateMealEntryPage());
@@ -66,14 +76,12 @@ export default class CreateMealEntryPageComponent implements OnInit {
   }
 
   public onSubmit() {
-    if (this.model.product && this.model.amount && this.model.amount > 0) {
-      const { amount, product } = this.model;
-      const { name, id, carbs } = product;
-      this.store.dispatch(
-        ComponentActions.saveClicked({
-          mealEntry: { amount, carbs, productId: id, name },
-        }),
-      );
-    }
+    const { product, amount } = this.formGroup.getRawValue();
+    this.store.dispatch(
+      ComponentActions.saveClicked({
+        product: product as Product,
+        amount: amount as number,
+      }),
+    );
   }
 }

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.selectors.spec.ts
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.selectors.spec.ts
@@ -1,0 +1,23 @@
+import { Product } from '../../../products-feature/product.model';
+import { selectCreateMealEntryPageViewModel } from './create-meal-entry-page.selectors';
+
+const createProduct = (id: string, name: string): Product => ({
+  id,
+  name,
+  creator: 'user-a',
+  carbs: 50,
+});
+
+describe('selectCreateMealEntryPageViewModel', () => {
+  it('exposes the filtered products available to add', () => {
+    const availableProducts = [
+      createProduct('p1', 'spaghetti'),
+      createProduct('p2', 'sauce'),
+    ];
+
+    const viewModel =
+      selectCreateMealEntryPageViewModel.projector(availableProducts);
+
+    expect(viewModel).toEqual({ availableProducts });
+  });
+});

--- a/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.selectors.ts
+++ b/apps/carbotracker/src/current-meal-feature/pages/CreateMealEntryPage/create-meal-entry-page.selectors.ts
@@ -15,3 +15,14 @@ export const selectFilteredProducts = createSelector(
     }
   },
 );
+
+export interface CreateMealEntryPageViewModel {
+  availableProducts: Product[];
+}
+
+export const selectCreateMealEntryPageViewModel = createSelector(
+  selectFilteredProducts,
+  (availableProducts): CreateMealEntryPageViewModel => ({
+    availableProducts,
+  }),
+);

--- a/apps/carbotracker/src/products-feature/+state/actions/component.actions.ts
+++ b/apps/carbotracker/src/products-feature/+state/actions/component.actions.ts
@@ -16,7 +16,6 @@ export const EditProductPageComponentActions = createActionGroup({
   events: {
     'Selected Product Changed': props<{ selectedProduct: string }>(),
     'Save Product Clicked': props<{
-      exisitingProduct: Product;
       changedProduct: Pick<Product, 'name' | 'carbs'>;
     }>(),
     'Delete Clicked': props<{ selectedProduct: Product }>(),

--- a/apps/carbotracker/src/products-feature/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/products-feature/+state/effects/api.effects.spec.ts
@@ -1,0 +1,100 @@
+import { Action, Store } from '@ngrx/store';
+import { of, Subject, throwError } from 'rxjs';
+import { ProductsService } from '../../services/products.service';
+import { ProductsApiActions } from '../actions/api.actions';
+import { EditProductPageComponentActions } from '../actions/component.actions';
+import { productsFeature } from '../products.reducer';
+import { updateProduct$ } from './api.effects';
+
+const selectedProduct = {
+  id: 'p1',
+  name: 'spaghetti',
+  creator: 'user-a',
+  carbs: 25,
+};
+
+const buildStore = (): Store =>
+  ({
+    select: jest.fn((selector) => {
+      if (selector === productsFeature.selectCurrentProduct) {
+        return of(selectedProduct);
+      }
+      return of(null);
+    }),
+  }) as unknown as Store;
+
+describe('updateProduct$', () => {
+  it('merges the existing product with the changed product and updates it', () => {
+    const productsService = {
+      updateProduct: jest.fn(() => of(undefined)),
+    } as unknown as ProductsService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    updateProduct$(actions$.asObservable(), productsService, buildStore()).subscribe(
+      (action) => results.push(action),
+    );
+
+    actions$.next(
+      EditProductPageComponentActions.saveProductClicked({
+        changedProduct: { name: 'rigatoni', carbs: 30 },
+      }),
+    );
+
+    expect(productsService.updateProduct).toHaveBeenCalledWith({
+      ...selectedProduct,
+      ...{ name: 'rigatoni', carbs: 30 },
+    });
+    expect(results).toEqual([ProductsApiActions.updatingProductSuccessful()]);
+  });
+
+  it('does nothing when there is no selected product', () => {
+    const productsService = {
+      updateProduct: jest.fn(() => of(undefined)),
+    } as unknown as ProductsService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    updateProduct$(
+      actions$.asObservable(),
+      productsService,
+      buildStoreWithNoProduct(),
+    ).subscribe((action) => results.push(action));
+
+    actions$.next(
+      EditProductPageComponentActions.saveProductClicked({
+        changedProduct: { name: 'rigatoni', carbs: 30 },
+      }),
+    );
+
+    expect(productsService.updateProduct).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it('dispatches updatingProductFailed when the update fails', () => {
+    const productsService = {
+      updateProduct: jest.fn(() => throwError(() => new Error('boom'))),
+    } as unknown as ProductsService;
+
+    const actions$ = new Subject<Action>();
+    const results: Action[] = [];
+    updateProduct$(actions$.asObservable(), productsService, buildStore()).subscribe(
+      (action) => results.push(action),
+    );
+
+    actions$.next(
+      EditProductPageComponentActions.saveProductClicked({
+        changedProduct: { name: 'rigatoni', carbs: 30 },
+      }),
+    );
+
+    expect(results).toEqual([
+      ProductsApiActions.updatingProductFailed({ error: expect.any(Error) }),
+    ]);
+  });
+});
+
+const buildStoreWithNoProduct = (): Store =>
+  ({
+    select: jest.fn(() => of(null)),
+  }) as unknown as Store;

--- a/apps/carbotracker/src/products-feature/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/products-feature/+state/effects/api.effects.spec.ts
@@ -31,9 +31,11 @@ describe('updateProduct$', () => {
 
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    updateProduct$(actions$.asObservable(), productsService, buildStore()).subscribe(
-      (action) => results.push(action),
-    );
+    updateProduct$(
+      actions$.asObservable(),
+      productsService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
 
     actions$.next(
       EditProductPageComponentActions.saveProductClicked({
@@ -78,9 +80,11 @@ describe('updateProduct$', () => {
 
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    updateProduct$(actions$.asObservable(), productsService, buildStore()).subscribe(
-      (action) => results.push(action),
-    );
+    updateProduct$(
+      actions$.asObservable(),
+      productsService,
+      buildStore(),
+    ).subscribe((action) => results.push(action));
 
     actions$.next(
       EditProductPageComponentActions.saveProductClicked({

--- a/apps/carbotracker/src/products-feature/+state/effects/api.effects.ts
+++ b/apps/carbotracker/src/products-feature/+state/effects/api.effects.ts
@@ -14,8 +14,8 @@ import {
   switchMap,
   tap,
 } from 'rxjs';
-import { authFeature } from '../../../features/auth/+state';
-import { SettingsPageActions } from '../../../features/settings/+state';
+import { authFeature } from '../../../features/auth/+state/auth.store';
+import { SettingsPageActions } from '../../../features/settings/+state/actions/component.actions';
 import { ProductsService } from '../../services/products.service';
 import { ProductsApiActions } from '../actions/api.actions';
 import {
@@ -24,6 +24,7 @@ import {
 } from '../actions/component.actions';
 import { DeleteProductConfirmationDialogActions } from '../actions/dialog.actions';
 import { ProductsRouterActions } from '../actions/routing.actions';
+import { productsFeature } from '../products.reducer';
 
 export const startStreamingProducts$ = createEffect(
   (
@@ -61,13 +62,20 @@ export const stopStreamingProducts$ = createEffect(
 );
 
 export const updateProduct$ = createEffect(
-  (actions$ = inject(Actions), productsService = inject(ProductsService)) =>
+  (
+    actions$ = inject(Actions),
+    productsService = inject(ProductsService),
+    store = inject(Store),
+  ) =>
     actions$.pipe(
       ofType(EditProductPageComponentActions.saveProductClicked),
-      exhaustMap(({ exisitingProduct, changedProduct }) =>
+      concatLatestFrom(() =>
+        store.select(productsFeature.selectCurrentProduct).pipe(filterNull()),
+      ),
+      exhaustMap(([{ changedProduct }, existingProduct]) =>
         productsService
           .updateProduct({
-            ...exisitingProduct,
+            ...existingProduct,
             ...changedProduct,
           })
           .pipe(

--- a/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.html
+++ b/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.html
@@ -1,29 +1,22 @@
 <ctui-toolbar
-  title="Create product"
+  [title]="viewModel().pageTitle"
   [showBackwardNavigation]="true"
   (backwardNavigation)="onGoBack()"
 >
 </ctui-toolbar>
-<form #productForm="ngForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
   <mat-form-field>
-    <mat-label formGroupBane>Product name</mat-label>
-    <input name="name" required type="text" [(ngModel)]="model.name" matInput />
+    <mat-label>Product name</mat-label>
+    <input formControlName="name" type="text" matInput />
   </mat-form-field>
   <mat-form-field>
     <mat-label>Carbohydrates per 100g</mat-label>
-    <input
-      name="carbs"
-      required
-      min="0.1"
-      type="number"
-      [(ngModel)]="model.carbs"
-      matInput
-    />
+    <input formControlName="carbs" type="number" matInput />
   </mat-form-field>
   <button
     color="primary"
     type="submit"
-    [disabled]="productForm.invalid || productForm.pristine"
+    [disabled]="formGroup.invalid || formGroup.pristine"
     mat-fab
     ctuiFixedPosition
     matTooltip="Save product"

--- a/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.html
+++ b/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.html
@@ -7,11 +7,11 @@
 <form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
   <mat-form-field>
     <mat-label>Product name</mat-label>
-    <input formControlName="name" type="text" matInput />
+    <input [formControl]="formGroup.controls.name" type="text" matInput />
   </mat-form-field>
   <mat-form-field>
     <mat-label>Carbohydrates per 100g</mat-label>
-    <input formControlName="carbs" type="number" matInput />
+    <input [formControl]="formGroup.controls.carbs" type="number" matInput />
   </mat-form-field>
   <button
     color="primary"

--- a/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.ts
+++ b/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -11,43 +16,51 @@ import {
 } from '@carbotracker/ui';
 import { Store } from '@ngrx/store';
 import { CreateProductPageComponentActions as ComponentActions } from '../../+state/actions/component.actions';
+import { selectCreateProductPageViewModel } from './create-product-page.selectors';
 
-type FormModel = { name: string; carbs: number | null };
+interface CreateProductFormControls {
+  name: FormControl<string>;
+  carbs: FormControl<number | null>;
+}
 
 @Component({
   selector: 'carbotracker-create-product-page',
   imports: [
-    FormsModule,
+    CtuiFixedPositionDirective,
+    CtuiToolbarComponent,
+    ReactiveFormsModule,
     MatButtonModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
     MatTooltipModule,
-    CtuiFixedPositionDirective,
-    CtuiToolbarComponent,
   ],
   templateUrl: './create-product-page.component.html',
   styleUrls: ['./create-product-page.component.scss'],
 })
 export default class CreateProductPageComponent {
   private readonly store = inject(Store);
+  protected readonly viewModel = this.store.selectSignal(
+    selectCreateProductPageViewModel,
+  );
 
-  public readonly model: FormModel = {
-    name: '',
-    carbs: null,
-  };
+  protected readonly formGroup = new FormGroup<CreateProductFormControls>({
+    name: new FormControl(this.viewModel().initialFormValues.name, {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    carbs: new FormControl(this.viewModel().initialFormValues.carbs, {
+      validators: [Validators.required, Validators.min(0.1)],
+    }),
+  });
 
   public onSubmit() {
-    if (this.model.carbs) {
-      this.store.dispatch(
-        ComponentActions.saveProductClicked({
-          newProduct: {
-            name: this.model.name,
-            carbs: this.model.carbs,
-          },
-        }),
-      );
-    }
+    const { name, carbs } = this.formGroup.getRawValue();
+    this.store.dispatch(
+      ComponentActions.saveProductClicked({
+        newProduct: { name, carbs: carbs as number },
+      }),
+    );
   }
 
   public onGoBack() {

--- a/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.selectors.spec.ts
+++ b/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.selectors.spec.ts
@@ -1,0 +1,12 @@
+import { selectCreateProductPageViewModel } from './create-product-page.selectors';
+
+describe('selectCreateProductPageViewModel', () => {
+  it('provides the page title and initial form values for a new product', () => {
+    const viewModel = selectCreateProductPageViewModel.projector();
+
+    expect(viewModel).toEqual({
+      pageTitle: 'Create product',
+      initialFormValues: { name: '', carbs: null },
+    });
+  });
+});

--- a/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.selectors.ts
+++ b/apps/carbotracker/src/products-feature/pages/CreateProductPage/create-product-page.selectors.ts
@@ -1,0 +1,13 @@
+import { createSelector } from '@ngrx/store';
+
+export interface CreateProductPageViewModel {
+  pageTitle: string;
+  initialFormValues: { name: string; carbs: number | null };
+}
+
+export const selectCreateProductPageViewModel = createSelector(
+  (): CreateProductPageViewModel => ({
+    pageTitle: 'Create product',
+    initialFormValues: { name: '', carbs: null },
+  }),
+);

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
@@ -20,7 +20,11 @@
       </mat-form-field>
       <mat-form-field>
         <mat-label>Carbohydrates per 100g</mat-label>
-        <input [formControl]="formGroup.controls.carbs" type="number" matInput />
+        <input
+          [formControl]="formGroup.controls.carbs"
+          type="number"
+          matInput
+        />
       </mat-form-field>
       <button
         color="primary"

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
@@ -1,7 +1,7 @@
-@if (product(); as product) {
+@if (viewModel().product; as product) {
   <ng-container>
     <ctui-toolbar
-      title="Edit product"
+      [title]="viewModel().pageTitle"
       [showBackwardNavigation]="true"
       (backwardNavigation)="onGoBack()"
     >
@@ -13,32 +13,19 @@
         <mat-icon>delete</mat-icon>
       </button>
     </ctui-toolbar>
-    <form #productForm="ngForm" (ngSubmit)="onSubmit()">
+    <form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
       <mat-form-field>
-        <mat-label formGroupBane>Product name</mat-label>
-        <input
-          name="name"
-          required
-          type="text"
-          [(ngModel)]="model.name"
-          matInput
-        />
+        <mat-label>Product name</mat-label>
+        <input formControlName="name" type="text" matInput />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Carbohydrates per 100g</mat-label>
-        <input
-          name="carbs"
-          required
-          min="0.1"
-          type="number"
-          [(ngModel)]="model.carbs"
-          matInput
-        />
+        <input formControlName="carbs" type="number" matInput />
       </mat-form-field>
       <button
         color="primary"
         type="submit"
-        [disabled]="productForm.invalid || productForm.pristine"
+        [disabled]="formGroup.invalid || formGroup.pristine"
         mat-fab
         ctuiFixedPosition
         matTooltip="Save product"

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.html
@@ -16,11 +16,11 @@
     <form [formGroup]="formGroup" (ngSubmit)="onSubmit()">
       <mat-form-field>
         <mat-label>Product name</mat-label>
-        <input formControlName="name" type="text" matInput />
+        <input [formControl]="formGroup.controls.name" type="text" matInput />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Carbohydrates per 100g</mat-label>
-        <input formControlName="carbs" type="number" matInput />
+        <input [formControl]="formGroup.controls.carbs" type="number" matInput />
       </mat-form-field>
       <button
         color="primary"

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.ts
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.component.ts
@@ -5,7 +5,12 @@ import {
   effect,
   inject,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -17,22 +22,25 @@ import {
 } from '@carbotracker/ui';
 import { Store } from '@ngrx/store';
 import { EditProductPageComponentActions as ComponentActions } from '../../+state/actions/component.actions';
-import { productsFeature } from '../../+state/products.reducer';
 import { Product } from '../../product.model';
+import { selectEditProductPageViewModel } from './edit-product-page.selectors';
 
-type FormModel = Pick<Product, 'name' | 'carbs'>;
+interface EditProductFormControls {
+  name: FormControl<string>;
+  carbs: FormControl<number>;
+}
 
 @Component({
   selector: 'carbotracker-edit-product-page',
   imports: [
     CtuiFixedPositionDirective,
-    FormsModule,
+    CtuiToolbarComponent,
+    ReactiveFormsModule,
     MatButtonModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
     MatTooltipModule,
-    CtuiToolbarComponent,
   ],
   templateUrl: './edit-product-page.component.html',
   styleUrls: ['./edit-product-page.component.scss'],
@@ -40,14 +48,20 @@ type FormModel = Pick<Product, 'name' | 'carbs'>;
 })
 export default class EditProductPageComponent {
   private readonly store = inject(Store);
-  public readonly product = this.store.selectSignal(
-    productsFeature.selectCurrentProduct,
+  protected readonly viewModel = this.store.selectSignal(
+    selectEditProductPageViewModel,
   );
 
-  public readonly model: FormModel = {
-    name: '',
-    carbs: 0,
-  };
+  protected readonly formGroup = new FormGroup<EditProductFormControls>({
+    name: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    carbs: new FormControl(0, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(0.1)],
+    }),
+  });
 
   constructor() {
     this.reactToProductChanges();
@@ -61,31 +75,26 @@ export default class EditProductPageComponent {
   }
 
   public onSubmit() {
-    const exisitingProduct = this.product();
-    if (exisitingProduct)
-      this.store.dispatch(
-        ComponentActions.saveProductClicked({
-          exisitingProduct,
-          changedProduct: { ...this.model },
-        }),
-      );
+    const { name, carbs } = this.formGroup.getRawValue();
+    this.store.dispatch(
+      ComponentActions.saveProductClicked({ changedProduct: { name, carbs } }),
+    );
   }
 
   public onDeleteClicked(selectedProduct: Product) {
     this.store.dispatch(ComponentActions.deleteClicked({ selectedProduct }));
   }
 
-  private reactToProductChanges() {
-    effect(() => {
-      const currentProduct = this.product();
-      if (currentProduct) {
-        this.model.name = currentProduct.name;
-        this.model.carbs = currentProduct.carbs;
-      }
-    });
-  }
-
   public onGoBack() {
     this.store.dispatch(ComponentActions.goBackIconClicked());
+  }
+
+  private reactToProductChanges() {
+    effect(() => {
+      const initialFormValues = this.viewModel().initialFormValues;
+      if (initialFormValues) {
+        this.formGroup.patchValue(initialFormValues, { emitEvent: false });
+      }
+    });
   }
 }

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.selectors.spec.ts
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.selectors.spec.ts
@@ -1,0 +1,34 @@
+import { Product } from '../../product.model';
+import { selectEditProductPageViewModel } from './edit-product-page.selectors';
+
+const createProduct = (overrides: Partial<Product> = {}): Product => ({
+  id: 'p1',
+  name: 'spaghetti',
+  creator: 'user-a',
+  carbs: 25,
+  ...overrides,
+});
+
+describe('selectEditProductPageViewModel', () => {
+  it('provides the current product as initial form values', () => {
+    const product = createProduct({ name: 'spaghetti', carbs: 25 });
+
+    const viewModel = selectEditProductPageViewModel.projector(product);
+
+    expect(viewModel).toEqual({
+      product,
+      pageTitle: 'Edit product',
+      initialFormValues: { name: 'spaghetti', carbs: 25 },
+    });
+  });
+
+  it('provides null initial form values when there is no selected product', () => {
+    const viewModel = selectEditProductPageViewModel.projector(null);
+
+    expect(viewModel).toEqual({
+      product: null,
+      pageTitle: 'Edit product',
+      initialFormValues: null,
+    });
+  });
+});

--- a/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.selectors.ts
+++ b/apps/carbotracker/src/products-feature/pages/EditProductPage/edit-product-page.selectors.ts
@@ -1,0 +1,20 @@
+import { createSelector } from '@ngrx/store';
+import { productsFeature } from '../../+state/products.reducer';
+import { Product } from '../../product.model';
+
+export interface EditProductPageViewModel {
+  product: Product | null;
+  pageTitle: string;
+  initialFormValues: Pick<Product, 'name' | 'carbs'> | null;
+}
+
+export const selectEditProductPageViewModel = createSelector(
+  productsFeature.selectCurrentProduct,
+  (product): EditProductPageViewModel => ({
+    product,
+    pageTitle: 'Edit product',
+    initialFormValues: product
+      ? { name: product.name, carbs: product.carbs }
+      : null,
+  }),
+);

--- a/docs/adr/0002-page-component-patterns.md
+++ b/docs/adr/0002-page-component-patterns.md
@@ -14,13 +14,13 @@ A second ambiguity: the codebase uses both template-driven forms (`FormsModule`)
 
 ### Two page archetypes
 
-| | Display page | Form page |
-|---|---|---|
-| **Reads** | `selectSignal(selectViewModel)` only | `selectSignal(selectViewModel)` + `FormGroup` |
-| **Writes** | `dispatch(action())` | `dispatch(action(formGroup.value))` |
-| **Sync** | None | `effect()` patches `formGroup` from `viewModel()` |
-| **Validation** | N/A | Declarative validators on `FormControl` |
-| **Example** | CurrentMealPage, SavedMealsPage | EditProductPage, login-page |
+|                | Display page                         | Form page                                         |
+| -------------- | ------------------------------------ | ------------------------------------------------- |
+| **Reads**      | `selectSignal(selectViewModel)` only | `selectSignal(selectViewModel)` + `FormGroup`     |
+| **Writes**     | `dispatch(action())`                 | `dispatch(action(formGroup.value))`               |
+| **Sync**       | None                                 | `effect()` patches `formGroup` from `viewModel()` |
+| **Validation** | N/A                                  | Declarative validators on `FormControl`           |
+| **Example**    | CurrentMealPage, SavedMealsPage      | EditProductPage, login-page                       |
 
 Every page gets a page-level `*.selectors.ts` file with a `select<Page>ViewModel` selector. Display-page viewModels compose derived display values. Form-page viewModels provide `initialFormValues` (to prime the form from store state), `pageTitle`, and any toolbar/chrome derived values. Create pages with nothing to prime from store expose their (static) initial values and page title through the viewModel so the component reads state only through the selector seam.
 
@@ -55,6 +55,7 @@ Reactive forms chosen because they (a) already have adoption in the codebase, (b
 ### Merge logic location (EditProductPage)
 
 For editing an existing entity, the save payload must merge the existing store entity with the form delta. Options:
+
 - **Component** merges before dispatching — requires the component to read store state.
 - **Selector** derives the merge — requires passing form values through the selector chain.
 - **Effect** reads the existing entity from store via `concatLatestFrom` and merges — component dispatches only the form delta.

--- a/docs/adr/0002-page-component-patterns.md
+++ b/docs/adr/0002-page-component-patterns.md
@@ -26,7 +26,7 @@ Every page gets a page-level `*.selectors.ts` file with a `select<Page>ViewModel
 
 ### Form approach: reactive forms
 
-All form pages use `ReactiveFormsModule` with a `FormGroup`. Validators are declared on `FormControl` — not guarded imperatively in the component. The component never checks `formGroup.valid` before dispatching; the template uses `[disabled]="formGroup.invalid"` on the submit button (plus `pristine` where saving an unchanged edit form is meaningless).
+All form pages use `ReactiveFormsModule` with a `FormGroup`. Controls bind to the template via the **`[formControl]="formGroup.controls.x"` property binding** — not the `formControlName` string directive — so a typo in a control name is a compile error, not a silent runtime failure. Validators are declared on `FormControl` — not guarded imperatively in the component. The component never checks `formGroup.valid` before dispatching; the template uses `[disabled]="formGroup.invalid"` on the submit button (plus `pristine` where saving an unchanged edit form is meaningless).
 
 ### Event-driven action chain
 

--- a/docs/adr/0002-page-component-patterns.md
+++ b/docs/adr/0002-page-component-patterns.md
@@ -1,0 +1,71 @@
+# 0002. Page component patterns
+
+- **Status:** Accepted
+- **Deciders:** carbotracker maintainers
+- **Date:** 2026-08-10
+
+## Context
+
+Pages in the codebase have diverged into two patterns — older pages embed guard logic, form sync, and payload construction inside the component class, while newer pages (CurrentMealPage, SavedMealsPage) follow a pure `selectSignal` + `dispatch` pattern. We need a single convention so every page is uniformly testable at the selector seam.
+
+A second ambiguity: the codebase uses both template-driven forms (`FormsModule`) and reactive forms (`ReactiveFormsModule`), sometimes in the same page. This inconsistency makes validation logic ad-hoc and prevents consistent page architecture.
+
+## Decision
+
+### Two page archetypes
+
+| | Display page | Form page |
+|---|---|---|
+| **Reads** | `selectSignal(selectViewModel)` only | `selectSignal(selectViewModel)` + `FormGroup` |
+| **Writes** | `dispatch(action())` | `dispatch(action(formGroup.value))` |
+| **Sync** | None | `effect()` patches `formGroup` from `viewModel()` |
+| **Validation** | N/A | Declarative validators on `FormControl` |
+| **Example** | CurrentMealPage, SavedMealsPage | EditProductPage, login-page |
+
+Every page gets a page-level `*.selectors.ts` file with a `select<Page>ViewModel` selector. Display-page viewModels compose derived display values. Form-page viewModels provide `initialFormValues` (to prime the form from store state), `pageTitle`, and any toolbar/chrome derived values. Create pages with nothing to prime from store expose their (static) initial values and page title through the viewModel so the component reads state only through the selector seam.
+
+### Form approach: reactive forms
+
+All form pages use `ReactiveFormsModule` with a `FormGroup`. Validators are declared on `FormControl` — not guarded imperatively in the component. The component never checks `formGroup.valid` before dispatching; the template uses `[disabled]="formGroup.invalid"` on the submit button (plus `pristine` where saving an unchanged edit form is meaningless).
+
+### Event-driven action chain
+
+Every user interaction flows through a strict chain:
+
+```
+Component dispatch → Effect (API call) → API Success/Failure action → Routing/Snackbar effects
+```
+
+Routing effects always listen to the **API success action** (`...Successful`), never the component action. This keeps the chain direct and avoids routing before the write completes. Snackbar effects show success or error messages on the corresponding API outcome.
+
+### No loading spinners, no blocked save buttons
+
+The app uses Firebase Firestore with real-time listeners. A local write hits the IndexedDB cache, triggers the listener, and pushes updated state into NgRx in the same event loop tick — so there is zero visible latency between saving and seeing the result. The UI does not show spinners or disable save buttons during writes. Errors surface reactively via snackbar on the `...Failed` actions.
+
+## Considered options
+
+### Template-driven vs reactive vs signal forms
+
+- **Template-driven forms** — already used in product/meal-entry pages. Would keep imperative guards in the component (the exact problem this refactor targets).
+- **Reactive forms** — already established in auth/settings pages. Validators are declarative and testable. Eliminates imperative `if (this.model.x)` guards from components.
+- **Signal forms** — Angular's newest API. Not yet adopted in the codebase. Would require team ramp-up and offers no advantage over reactive forms for this app's form complexity.
+
+Reactive forms chosen because they (a) already have adoption in the codebase, (b) directly eliminate the component logic targeted by this refactor, and (c) are battle-tested across all supported Angular versions.
+
+### Merge logic location (EditProductPage)
+
+For editing an existing entity, the save payload must merge the existing store entity with the form delta. Options:
+- **Component** merges before dispatching — requires the component to read store state.
+- **Selector** derives the merge — requires passing form values through the selector chain.
+- **Effect** reads the existing entity from store via `concatLatestFrom` and merges — component dispatches only the form delta.
+
+Effect merge chosen: keeps the component thinnest, and the merge belongs to the data layer.
+
+## Consequences
+
+- Product, meal-entry, and other older form pages migrate to `ReactiveFormsModule` + `FormGroup`.
+- Three pages in scope for immediate refactor: CreateProductPage, EditProductPage, CreateMealEntryPage.
+- EditMealEntryPage and SavedMealNameDialog remain as follow-up work (same pattern, different ticket).
+- `CreateMealEntryPage` routing effect changes from listening to `saveClicked` to `addMealEntrySuccessful` — aligning with the event-driven chain.
+- `EditProductPageComponentActions.saveProductClicked` drops the `exisitingProduct` prop — the effect derives it.
+- `CreateMealEntryPageComponentActions.saveClicked` changes from `{ mealEntry }` to `{ product, amount }` — the effect constructs the MealEntry.


### PR DESCRIPTION
## Summary

Closes #188. Refactors the three pre-pattern form pages to the repo's `selectSignal + dispatch` architecture so all pages are uniformly testable at the selector seam. Establishes ADR 0002 (`docs/adr/0002-page-component-patterns.md`) documenting the two page archetypes and the event-driven action chain.

## Changes

### CreateProductPage / EditProductPage / CreateMealEntryPage
- Switch from template-driven forms to **reactive forms** with declarative validators. The imperative guards (`if (this.model.carbs)`, the meal-entry model guard) move into `FormControl` validators; components no longer guard submit.
- Each page gets a page-level `*.selectors.ts` with a `select<Page>ViewModel`:
  - `create-product-page.selectors.ts` → `selectCreateProductPageViewModel`
  - `edit-product-page.selectors.ts` → `selectEditProductPageViewModel` (primes the form from `selectCurrentProduct`)
  - `create-meal-entry-page.selectors.ts` → `selectCreateMealEntryPageViewModel` (wraps `selectFilteredProducts`)

### Event-driven chain
- **EditProductPage**: `saveProductClicked` drops the `exisitingProduct` prop; the `updateProduct$` effect derives the current product from the store and merges the form delta.
- **CreateMealEntryPage**: `saveClicked` now takes `{ product, amount }`; the `addMealEntryToCurrentMeal` effect constructs the `MealEntry`. Navigation moves to `addMealEntrySuccessful`, completing the chain (component → effect → API action → routing).

## Testing
- New selector specs for all three page viewModels
- New products `updateProduct$` effect spec (merge + no-product + failure)
- New current-meal routing effect spec
- Updated `addMealEntryToCurrentMeal` spec for the new action shape
- Full suite: 38 tests passing; typecheck, lint, and dev build clean

## Notes
- `EditMealEntryPage` and `SavedMealNameDialog` still use the old pattern — follow-up tickets, out of scope here.
- Loading-state (`isSaving`) is intentionally absent: Firebase local cache makes writes appear instant, per ADR 0002.