### PR TITLE
Implement worktree creation, opencode launch, and PR tracking (#218)

### DIFF
--- a/tools/carbotracker-orchestrator.service
+++ b/tools/carbotracker-orchestrator.service
@@ -16,6 +16,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+WorkingDirectory=%h/git/carbotracker
 ExecStart=%h/git/carbotracker/tools/ct-orchestrator.sh
 Restart=on-failure
 RestartSec=10

--- a/tools/ct-lib.sh
+++ b/tools/ct-lib.sh
@@ -66,6 +66,20 @@ ct_merged_pr_count() {
   gh pr list --head "$1" --state merged --json number --jq 'length' 2>/dev/null || echo 0
 }
 
+ct_worktree_add() {
+  local dir="$1" branch="$2"
+
+  git fetch origin main || return 1
+
+  if [[ -d "$dir" ]]; then
+    echo "Error: Worktree already exists at $dir" >&2
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$dir")" || return 1
+  git worktree add "$dir" -b "$branch" origin/main || return 1
+}
+
 ct_worktree_create() {
   local issue_number="$1"
   local title slug
@@ -85,15 +99,7 @@ ct_worktree_create() {
   echo "Path:   $CT_WORKTREE_DIR"
   echo ""
 
-  git fetch origin main || return 1
-
-  if [[ -d "$CT_WORKTREE_DIR" ]]; then
-    echo "Error: Worktree already exists at $CT_WORKTREE_DIR" >&2
-    return 1
-  fi
-
-  mkdir -p "$WORKTREE_PARENT" || return 1
-  git worktree add "$CT_WORKTREE_DIR" -b "$CT_WORKTREE_BRANCH" origin/main || return 1
+  ct_worktree_add "$CT_WORKTREE_DIR" "$CT_WORKTREE_BRANCH" || return 1
 }
 
 ct_worktree_list() {

--- a/tools/ct-lib.sh
+++ b/tools/ct-lib.sh
@@ -71,6 +71,7 @@ ct_merged_pr_count() {
 ct_worktree_add() {
   local dir="$1" branch="$2"
 
+  CT_WORKTREE_CREATED=0
   git fetch origin main || return 1
 
   if [[ -d "$dir" ]]; then
@@ -80,6 +81,7 @@ ct_worktree_add() {
 
   mkdir -p "$(dirname "$dir")" || return 1
   git worktree add "$dir" -b "$branch" origin/main || return 1
+  CT_WORKTREE_CREATED=1
 }
 
 ct_worktree_create() {

--- a/tools/ct-lib.sh
+++ b/tools/ct-lib.sh
@@ -3,7 +3,9 @@
 WORKTREE_PARENT="$HOME/git/worktrees/carbotracker"
 
 slugify() {
-  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
+  # LC_ALL=C keeps character ranges ASCII-only so output is identical under
+  # any locale (UTF-8 would let non-ASCII through into branch names).
+  printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C sed 's/[^a-z0-9]/-/g' | LC_ALL=C sed 's/--*/-/g' | LC_ALL=C sed 's/^-//;s/-$//'
 }
 
 ct_issue_title() {

--- a/tools/ct-orchestrator.conf
+++ b/tools/ct-orchestrator.conf
@@ -10,6 +10,11 @@ ORCHESTRATOR_CONCURRENCY_CAP=3
 # Labels a candidate issue must carry (comma-separated).
 ORCHESTRATOR_ISSUE_LABELS=ready-for-agent,ticket
 
+# Label applied on claim (ready-for-agent is removed, taking the issue out
+# of every orchestrator's candidate query so parallel daemons cannot
+# double-claim it).
+ORCHESTRATOR_IN_PROGRESS_LABEL=in-progress
+
 # JSON state file tracking active tickets.
 ORCHESTRATOR_STATE_FILE="$HOME/.local/state/carbotracker/orchestrator.json"
 

--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -24,7 +24,9 @@ ORCHESTRATOR_WORKTREE_PARENT="${ENV_ORCHESTRATOR_WORKTREE_PARENT:-${ORCHESTRATOR
 ORCHESTRATOR_ISSUE_LABELS="${ENV_ORCHESTRATOR_ISSUE_LABELS:-${ORCHESTRATOR_ISSUE_LABELS:-ready-for-agent,ticket}}"
 
 orchestrator_log() {
-  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+  # Logs go to stderr so functions that print a value on stdout (e.g. the
+  # state helpers or push_and_open_pr) never pollute it with log lines.
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
 }
 
 orchestrator_state_load() {
@@ -112,6 +114,32 @@ orchestrator_pr_number_for_branch() {
     | jq -r 'sort_by(.number) | reverse | .[0].number // empty' 2>/dev/null || true
 }
 
+orchestrator_push_and_open_pr() {
+  local number="$1" title="$2" branch="$3" worktree="$4"
+  local pr_number
+  orchestrator_log "pushing branch $branch for #$number"
+  # git push / gh pr create write progress and the PR url to stdout; this
+  # function's stdout is its return value, so route them to stderr.
+  if ! (cd "$worktree" && git push -u origin "$branch" >&2); then
+    orchestrator_log "ERROR: git push failed for #$number"
+    return 1
+  fi
+  pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  if [[ -z "$pr_number" ]]; then
+    orchestrator_log "creating PR for #$number ($title)"
+    if ! gh pr create --base main --head "$branch" --title "Implement $title (#$number)" \
+        --body "Automated implementation of #$number.
+
+---
+_Created by carbotracker's agent skills._" >&2; then
+      orchestrator_log "ERROR: gh pr create failed for #$number"
+      return 1
+    fi
+    pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  fi
+  printf '%s' "$pr_number"
+}
+
 orchestrator_cleanup_worktree() {
   local worktree="$1" branch="$2"
   git worktree remove --force "$worktree" 2>/dev/null || rm -rf "$worktree"
@@ -119,7 +147,7 @@ orchestrator_cleanup_worktree() {
 }
 
 orchestrator_implement() {
-  local number="$1" branch="$2" worktree="$3"
+  local number="$1" title="$2" branch="$3" worktree="$4"
   local session_title session_id pr_number
 
   orchestrator_log "implementing #$number: creating worktree $worktree (branch $branch)"
@@ -142,7 +170,10 @@ orchestrator_implement() {
   fi
 
   session_id="$(orchestrator_opencode_session_id "$session_title")"
-  pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  if ! pr_number="$(orchestrator_push_and_open_pr "$number" "$title" "$branch" "$worktree")"; then
+    orchestrator_log "ERROR: push or PR creation failed for #$number"
+    return 1
+  fi
   orchestrator_state_complete "$ORCHESTRATOR_STATE_FILE" "$number" "$session_id" "$pr_number"
 
   orchestrator_log "completed #$number: session ${session_id:-<none>}, PR #${pr_number:-<none>}, phase awaiting review"
@@ -190,7 +221,7 @@ orchestrator_poll_once() {
     orchestrator_claim "$number" "$branch" "$worktree"
     active_count=$((active_count + 1))
 
-    if ! orchestrator_implement "$number" "$branch" "$worktree"; then
+    if ! orchestrator_implement "$number" "$title" "$branch" "$worktree"; then
       orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
       orchestrator_log "removed #$number from state after failed implementation"
       orchestrator_cleanup_worktree "$worktree" "$branch"

--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -11,6 +11,7 @@ ENV_ORCHESTRATOR_CONCURRENCY_CAP="${ORCHESTRATOR_CONCURRENCY_CAP-}"
 ENV_ORCHESTRATOR_STATE_FILE="${ORCHESTRATOR_STATE_FILE-}"
 ENV_ORCHESTRATOR_WORKTREE_PARENT="${ORCHESTRATOR_WORKTREE_PARENT-}"
 ENV_ORCHESTRATOR_ISSUE_LABELS="${ORCHESTRATOR_ISSUE_LABELS-}"
+ENV_ORCHESTRATOR_IN_PROGRESS_LABEL="${ORCHESTRATOR_IN_PROGRESS_LABEL-}"
 
 CONF_FILE="${CT_ORCHESTRATOR_CONF:-$SCRIPT_DIR/ct-orchestrator.conf}"
 if [[ -f "$CONF_FILE" ]]; then
@@ -22,6 +23,7 @@ ORCHESTRATOR_CONCURRENCY_CAP="${ENV_ORCHESTRATOR_CONCURRENCY_CAP:-${ORCHESTRATOR
 ORCHESTRATOR_STATE_FILE="${ENV_ORCHESTRATOR_STATE_FILE:-${ORCHESTRATOR_STATE_FILE:-$HOME/.local/state/carbotracker/orchestrator.json}}"
 ORCHESTRATOR_WORKTREE_PARENT="${ENV_ORCHESTRATOR_WORKTREE_PARENT:-${ORCHESTRATOR_WORKTREE_PARENT:-$HOME/git/worktrees/carbotracker}}"
 ORCHESTRATOR_ISSUE_LABELS="${ENV_ORCHESTRATOR_ISSUE_LABELS:-${ORCHESTRATOR_ISSUE_LABELS:-ready-for-agent,ticket}}"
+ORCHESTRATOR_IN_PROGRESS_LABEL="${ENV_ORCHESTRATOR_IN_PROGRESS_LABEL:-${ORCHESTRATOR_IN_PROGRESS_LABEL:-in-progress}}"
 
 orchestrator_log() {
   # Logs go to stderr so functions that print a value on stdout (e.g. the
@@ -97,6 +99,13 @@ orchestrator_state_remove() {
 
 orchestrator_claim() {
   local number="$1" branch="$2" worktree="$3"
+  # The claim is the GitHub-side label flip: dropping ready-for-agent takes
+  # the issue out of every orchestrator's candidate query, so parallel
+  # daemons cannot double-claim it. The state file entry is the local record.
+  if ! gh issue edit "$number" --remove-label ready-for-agent --add-label "$ORCHESTRATOR_IN_PROGRESS_LABEL"; then
+    orchestrator_log "ERROR: failed to mark #$number as $ORCHESTRATOR_IN_PROGRESS_LABEL on GitHub"
+    return 1
+  fi
   orchestrator_state_add "$ORCHESTRATOR_STATE_FILE" "$number" "$branch" "$worktree"
   orchestrator_log "claim #$number: phase implementing, worktree $worktree on branch $branch"
 }
@@ -218,13 +227,21 @@ orchestrator_poll_once() {
     slug="$(slugify "$title")"
     branch="ticket/$number-$slug"
     worktree="$ORCHESTRATOR_WORKTREE_PARENT/$number-$slug"
-    orchestrator_claim "$number" "$branch" "$worktree"
+    if ! orchestrator_claim "$number" "$branch" "$worktree"; then
+      orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+      orchestrator_log "claim failed for #$number; removed from state"
+      continue
+    fi
     active_count=$((active_count + 1))
 
     if ! orchestrator_implement "$number" "$title" "$branch" "$worktree"; then
       orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
       orchestrator_log "removed #$number from state after failed implementation"
-      orchestrator_cleanup_worktree "$worktree" "$branch"
+      if [[ "${CT_WORKTREE_CREATED:-0}" == "1" ]]; then
+        orchestrator_cleanup_worktree "$worktree" "$branch"
+      else
+        orchestrator_log "not cleaning up pre-existing worktree $worktree"
+      fi
       active_count=$((active_count - 1))
     fi
   done < <(printf '%s' "$candidates" | jq -c '.[]')

--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -54,7 +54,7 @@ orchestrator_state_write() {
 }
 
 orchestrator_state_active_count() {
-  orchestrator_state_load "$1" | jq 'length'
+  orchestrator_state_load "$1" | jq '[.[] | select(.phase == "implementing")] | length'
 }
 
 orchestrator_state_has_ticket() {
@@ -76,18 +76,89 @@ orchestrator_state_add() {
   orchestrator_state_write "$state_file" "$state"
 }
 
+orchestrator_state_complete() {
+  local state_file="$1" number="$2" session_id="$3" pr_number="$4"
+  local state
+  state="$(orchestrator_state_load "$state_file")"
+  state="$(printf '%s' "$state" | jq --argjson n "$number" --arg sid "$session_id" --arg prn "$pr_number" \
+    '(.[] | select(.ticket == $n)) |= (.sessionId = (if $sid == "" then null else $sid end) | .prNumber = (if $prn == "" then null else ($prn | tonumber) end) | .phase = "awaiting review")')"
+  orchestrator_state_write "$state_file" "$state"
+}
+
+orchestrator_state_remove() {
+  local state_file="$1" number="$2"
+  local state
+  state="$(orchestrator_state_load "$state_file")"
+  state="$(printf '%s' "$state" | jq --argjson n "$number" 'map(select(.ticket != $n))')"
+  orchestrator_state_write "$state_file" "$state"
+}
+
 orchestrator_claim() {
-  local number="$1" title="$2"
-  local slug branch worktree
-  slug="$(slugify "$title")"
-  branch="ticket/$number-$slug"
-  worktree="$ORCHESTRATOR_WORKTREE_PARENT/$number-$slug"
+  local number="$1" branch="$2" worktree="$3"
   orchestrator_state_add "$ORCHESTRATOR_STATE_FILE" "$number" "$branch" "$worktree"
-  orchestrator_log "claim #$number ($title): phase implementing (would create worktree $worktree on branch $branch)"
+  orchestrator_log "claim #$number: phase implementing, worktree $worktree on branch $branch"
+}
+
+orchestrator_opencode_session_id() {
+  local title="$1"
+  opencode session list --format json 2>/dev/null \
+    | jq -r --arg t "$title" \
+        '[.[] | select(.title == $t)] | sort_by(.created) | reverse | .[0].id // empty'
+}
+
+orchestrator_pr_number_for_branch() {
+  local branch="$1"
+  gh pr list --head "$branch" --json number 2>/dev/null \
+    | jq -r 'sort_by(.number) | reverse | .[0].number // empty' 2>/dev/null || true
+}
+
+orchestrator_cleanup_worktree() {
+  local worktree="$1" branch="$2"
+  git worktree remove --force "$worktree" 2>/dev/null || rm -rf "$worktree"
+  git branch -D "$branch" 2>/dev/null || true
+}
+
+orchestrator_implement() {
+  local number="$1" branch="$2" worktree="$3"
+  local session_title session_id pr_number
+
+  orchestrator_log "implementing #$number: creating worktree $worktree (branch $branch)"
+  if ! ct_worktree_add "$worktree" "$branch"; then
+    orchestrator_log "ERROR: worktree creation failed for #$number"
+    return 1
+  fi
+
+  orchestrator_log "installing dependencies in $worktree"
+  if ! (cd "$worktree" && npm ci --prefer-offline --no-audit --no-fund); then
+    orchestrator_log "ERROR: npm ci failed for #$number"
+    return 1
+  fi
+
+  session_title="carbotracker-ticket-$number"
+  orchestrator_log "launching opencode for #$number (title $session_title)"
+  if ! (cd "$worktree" && opencode run --auto --title "$session_title" "/implement the issue is $number"); then
+    orchestrator_log "ERROR: opencode run failed for #$number"
+    return 1
+  fi
+
+  session_id="$(orchestrator_opencode_session_id "$session_title")"
+  pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  orchestrator_state_complete "$ORCHESTRATOR_STATE_FILE" "$number" "$session_id" "$pr_number"
+
+  orchestrator_log "completed #$number: session ${session_id:-<none>}, PR #${pr_number:-<none>}, phase awaiting review"
+  if [[ -n "$pr_number" ]]; then
+    if gh issue comment "$number" --body "Started implementation. PR #$pr_number created."; then
+      orchestrator_log "commented on #$number: Started implementation. PR #$pr_number created."
+    else
+      orchestrator_log "WARNING: failed to comment on #$number"
+    fi
+  else
+    orchestrator_log "WARNING: no PR found for branch $branch on #$number; skipping issue comment"
+  fi
 }
 
 orchestrator_poll_once() {
-  local candidates active_count count line number title
+  local candidates active_count count line number title slug branch worktree
   candidates="$(ct_candidate_issues)"
   active_count="$(orchestrator_state_active_count "$ORCHESTRATOR_STATE_FILE")"
   count="$(printf '%s' "$candidates" | jq 'length')"
@@ -113,8 +184,18 @@ orchestrator_poll_once() {
       continue
     fi
 
-    orchestrator_claim "$number" "$title"
+    slug="$(slugify "$title")"
+    branch="ticket/$number-$slug"
+    worktree="$ORCHESTRATOR_WORKTREE_PARENT/$number-$slug"
+    orchestrator_claim "$number" "$branch" "$worktree"
     active_count=$((active_count + 1))
+
+    if ! orchestrator_implement "$number" "$branch" "$worktree"; then
+      orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+      orchestrator_log "removed #$number from state after failed implementation"
+      orchestrator_cleanup_worktree "$worktree" "$branch"
+      active_count=$((active_count - 1))
+    fi
   done < <(printf '%s' "$candidates" | jq -c '.[]')
 }
 

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -42,15 +42,15 @@ Active tickets live in a single JSON array, written atomically
 ]
 ```
 
-Field            | Meaning
------------------|--------------------------------------------------------
-`ticket`         | GitHub issue number being implemented
-`branch`         | `ticket/<issue>-<slug>` branch the work happens on
-`worktree`       | Absolute path of the git worktree for that branch
-`sessionId`      | opencode session id for the run (`null` until it exits)
-`prNumber`       | PR opened for the branch (`null` until it exists)
-`phase`          | `implementing` or `awaiting review`
-`startedAt`      | UTC timestamp of the claim
+| Field       | Meaning                                                 |
+| ----------- | ------------------------------------------------------- |
+| `ticket`    | GitHub issue number being implemented                   |
+| `branch`    | `ticket/<issue>-<slug>` branch the work happens on      |
+| `worktree`  | Absolute path of the git worktree for that branch       |
+| `sessionId` | opencode session id for the run (`null` until it exits) |
+| `prNumber`  | PR opened for the branch (`null` until it exists)       |
+| `phase`     | `implementing` or `awaiting review`                     |
+| `startedAt` | UTC timestamp of the claim                              |
 
 ## Data flow per poll
 
@@ -80,13 +80,13 @@ opened it hands off to a human.
 Sourced from `ct-orchestrator.conf` (environment variables win over the conf
 file, which wins over defaults):
 
-| Variable                              | Default                                              |
-|---------------------------------------|------------------------------------------------------|
-| `ORCHESTRATOR_POLL_INTERVAL_SECONDS`  | `300`                                                |
-| `ORCHESTRATOR_CONCURRENCY_CAP`        | `3`                                                  |
-| `ORCHESTRATOR_ISSUE_LABELS`           | `ready-for-agent,ticket`                             |
-| `ORCHESTRATOR_STATE_FILE`             | `$HOME/.local/state/carbotracker/orchestrator.json`  |
-| `ORCHESTRATOR_WORKTREE_PARENT`        | `$HOME/git/worktrees/carbotracker`                   |
+| Variable                             | Default                                             |
+| ------------------------------------ | --------------------------------------------------- |
+| `ORCHESTRATOR_POLL_INTERVAL_SECONDS` | `300`                                               |
+| `ORCHESTRATOR_CONCURRENCY_CAP`       | `3`                                                 |
+| `ORCHESTRATOR_ISSUE_LABELS`          | `ready-for-agent,ticket`                            |
+| `ORCHESTRATOR_STATE_FILE`            | `$HOME/.local/state/carbotracker/orchestrator.json` |
+| `ORCHESTRATOR_WORKTREE_PARENT`       | `$HOME/git/worktrees/carbotracker`                  |
 
 ## Running
 

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -1,0 +1,108 @@
+# Carbotracker orchestrator
+
+`ct-orchestrator.sh` is the ticket-to-PR pipeline: it polls GitHub for
+`ready-for-agent` tickets, claims them up to a concurrency cap, and runs each
+one through a full implementation cycle — worktree, dependency install,
+headless `opencode`, and finally a pushed branch with a pull request. It runs
+as a systemd user service (see `carbotracker-orchestrator.service`).
+
+## Lifecycle
+
+A ticket moves through phases as the orchestrator works it:
+
+```mermaid
+stateDiagram-v2
+    [*] --> implementing: poll finds eligible ticket, claim
+    implementing --> awaiting_review: opencode done, PR opened
+    implementing --> [*]: failure, un-claim and clean up
+    awaiting_review --> [*]: human merges the PR
+```
+
+`implementing` means the orchestrator is actively running a session for the
+ticket; `awaiting review` means the PR exists and a human should look at it.
+Only `implementing` entries count against the concurrency cap.
+
+## State file
+
+Active tickets live in a single JSON array, written atomically
+(temp file + rename). Default location:
+`$HOME/.local/state/carbotracker/orchestrator.json`.
+
+```json
+[
+  {
+    "ticket": 218,
+    "branch": "ticket/218-worktree-creation-opencode-implementation-and-pr-tracking",
+    "worktree": "/home/steffen/git/worktrees/carbotracker/218-worktree-creation-opencode-implementation-and-pr-tracking",
+    "sessionId": "ses_007927ec0ffeYJFyKLBlmBSp1e",
+    "prNumber": 234,
+    "phase": "awaiting review",
+    "startedAt": "2026-08-13T00:07:00Z"
+  }
+]
+```
+
+Field            | Meaning
+-----------------|--------------------------------------------------------
+`ticket`         | GitHub issue number being implemented
+`branch`         | `ticket/<issue>-<slug>` branch the work happens on
+`worktree`       | Absolute path of the git worktree for that branch
+`sessionId`      | opencode session id for the run (`null` until it exits)
+`prNumber`       | PR opened for the branch (`null` until it exists)
+`phase`          | `implementing` or `awaiting review`
+`startedAt`      | UTC timestamp of the claim
+
+## Data flow per poll
+
+```mermaid
+flowchart TD
+    A[gh issue list ready-for-agent,ticket] --> B{unblocked? skip already-claimed / blocked / at cap}
+    B -- eligible --> C[claim: append state entry, phase implementing]
+    C --> D[ct_worktree_add: git fetch origin/main + worktree add -b ticket/N-slug]
+    D --> E[npm ci --prefer-offline --no-audit --no-fund]
+    E --> F[opencode run --auto --title carbotracker-ticket-N /implement the issue is N]
+    F --> G[opencode session list → sessionId by title]
+    G --> H[git push -u origin branch]
+    H --> I{PR exists?}
+    I -- no --> J[gh pr create --base main --head branch]
+    I -- yes --> K
+    J --> K[gh pr list --head branch → prNumber]
+    K --> L[state: sessionId + prNumber, phase awaiting review]
+    L --> M[gh issue comment: Started implementation. PR #N created.]
+    F -- failure --> N[un-claim + remove worktree/branch, retry next poll]
+```
+
+The orchestrator never resolves review threads or merges — after the PR is
+opened it hands off to a human.
+
+## Configuration
+
+Sourced from `ct-orchestrator.conf` (environment variables win over the conf
+file, which wins over defaults):
+
+| Variable                              | Default                                              |
+|---------------------------------------|------------------------------------------------------|
+| `ORCHESTRATOR_POLL_INTERVAL_SECONDS`  | `300`                                                |
+| `ORCHESTRATOR_CONCURRENCY_CAP`        | `3`                                                  |
+| `ORCHESTRATOR_ISSUE_LABELS`           | `ready-for-agent,ticket`                             |
+| `ORCHESTRATOR_STATE_FILE`             | `$HOME/.local/state/carbotracker/orchestrator.json`  |
+| `ORCHESTRATOR_WORKTREE_PARENT`        | `$HOME/git/worktrees/carbotracker`                   |
+
+## Running
+
+- `ct-orchestrator.sh` — run the daemon (systemd user service).
+- `ct-orchestrator.sh once` — run a single poll cycle and exit.
+- `ct-orchestrator.sh help` — show usage.
+
+Follow the daemon with `journalctl --user -u carbotracker-orchestrator -f`.
+
+## Design notes
+
+- Branch/worktree naming is derived once in the poll loop (`slugify`) and
+  handed to `ct_worktree_add`, so the state file and the actual worktree can
+  never drift apart.
+- A failed step un-claims the ticket and removes the worktree and branch, so
+  the next poll starts clean. This means push/PR failures retry the whole
+  `opencode` run, which is wasteful but simple and safe.
+- `orchestrator_log` writes to stderr: several helpers return their value on
+  stdout inside `$(...)`, so log lines must never land there.

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -12,7 +12,7 @@ A ticket moves through phases as the orchestrator works it:
 
 ```mermaid
 stateDiagram-v2
-    [*] --> implementing: poll finds eligible ticket, claim
+    [*] --> implementing: poll finds eligible ticket, claim flips GitHub labels
     implementing --> awaiting_review: opencode done, PR opened
     implementing --> [*]: failure, un-claim and clean up
     awaiting_review --> [*]: human merges the PR
@@ -21,6 +21,12 @@ stateDiagram-v2
 `implementing` means the orchestrator is actively running a session for the
 ticket; `awaiting review` means the PR exists and a human should look at it.
 Only `implementing` entries count against the concurrency cap.
+
+A claim is recorded **twice**: on the GitHub issue (remove `ready-for-agent`,
+add `in-progress`) and in the local state file. The label flip is what makes
+the claim visible to humans and atomic against parallel orchestrators — once
+an issue drops `ready-for-agent` it stops matching the candidate query, so a
+second daemon cannot claim it.
 
 ## State file
 
@@ -57,7 +63,7 @@ Active tickets live in a single JSON array, written atomically
 ```mermaid
 flowchart TD
     A[gh issue list ready-for-agent,ticket] --> B{unblocked? skip already-claimed / blocked / at cap}
-    B -- eligible --> C[claim: append state entry, phase implementing]
+    B -- eligible --> C[claim: remove ready-for-agent, add in-progress + append state entry]
     C --> D[ct_worktree_add: git fetch origin/main + worktree add -b ticket/N-slug]
     D --> E[npm ci --prefer-offline --no-audit --no-fund]
     E --> F[opencode run --auto --title carbotracker-ticket-N /implement the issue is N]
@@ -85,6 +91,7 @@ file, which wins over defaults):
 | `ORCHESTRATOR_POLL_INTERVAL_SECONDS` | `300`                                               |
 | `ORCHESTRATOR_CONCURRENCY_CAP`       | `3`                                                 |
 | `ORCHESTRATOR_ISSUE_LABELS`          | `ready-for-agent,ticket`                            |
+| `ORCHESTRATOR_IN_PROGRESS_LABEL`     | `in-progress`                                       |
 | `ORCHESTRATOR_STATE_FILE`            | `$HOME/.local/state/carbotracker/orchestrator.json` |
 | `ORCHESTRATOR_WORKTREE_PARENT`       | `$HOME/git/worktrees/carbotracker`                  |
 
@@ -103,6 +110,9 @@ Follow the daemon with `journalctl --user -u carbotracker-orchestrator -f`.
   never drift apart.
 - A failed step un-claims the ticket and removes the worktree and branch, so
   the next poll starts clean. This means push/PR failures retry the whole
-  `opencode` run, which is wasteful but simple and safe.
+  `opencode` run, which is wasteful but simple and safe. Cleanup is guarded:
+  only a worktree this run actually created (`CT_WORKTREE_CREATED`) is
+  removed, so a parallel orchestrator that loses the claim race never deletes
+  the winner's worktree.
 - `orchestrator_log` writes to stderr: several helpers return their value on
   stdout inside `$(...)`, so log lines must never land there.

--- a/tools/tests/ct-lib.test.sh
+++ b/tools/tests/ct-lib.test.sh
@@ -178,6 +178,51 @@ exit 0'
   fi
 }
 
+test_worktree_add() {
+  local parent dir
+  parent="/tmp/opencode/ct-add-parent"
+  dir="$parent/10-alpha"
+  rm -rf "$parent"
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+fi
+exit 0'
+  if ct_worktree_add "$dir" ticket/10-alpha; then
+    pass "add succeeds"
+  else
+    fail "add succeeds"
+  fi
+  assert_eq "add makes the worktree dir" "yes" "$([[ -d "$dir" ]] && echo yes || echo no)"
+  rm -rf "$parent"
+}
+
+test_worktree_add_existing_dir() {
+  local parent dir
+  parent="/tmp/opencode/ct-add-parent"
+  dir="$parent/10-alpha"
+  rm -rf "$parent"
+  mkdir -p "$dir"
+  fake_command git 'exit 0'
+  if ct_worktree_add "$dir" ticket/10-alpha >/dev/null 2>&1; then
+    fail "add fails when dir exists"
+  else
+    pass "add fails when dir exists"
+  fi
+  rm -rf "$parent"
+}
+
+test_worktree_add_fetch_fails() {
+  fake_command git 'if [[ "$1" == "fetch" ]]; then
+  exit 1
+fi
+exit 0'
+  if ct_worktree_add /tmp/opencode/ct-add-parent/10-alpha ticket/10-alpha >/dev/null 2>&1; then
+    fail "add fails when git fetch fails"
+  else
+    pass "add fails when git fetch fails"
+  fi
+}
+
 test_worktree_prune() {
   local repo parent pruned_dir branch
   repo="/tmp/opencode/ct-prune-repo"
@@ -310,6 +355,10 @@ WORKTREE_PARENT=/tmp/opencode/ct-test-parent run_test test_worktree_create
 WORKTREE_PARENT=/tmp/opencode/ct-test-parent run_test test_worktree_create_existing_dir
 WORKTREE_PARENT=/tmp/opencode/ct-test-parent run_test test_worktree_create_missing_issue
 WORKTREE_PARENT=/tmp/opencode/ct-test-parent run_test test_worktree_create_fetch_fails
+
+run_test test_worktree_add
+run_test test_worktree_add_existing_dir
+run_test test_worktree_add_fetch_fails
 
 run_test test_worktree_prune
 run_test test_worktree_prune_nothing

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -736,6 +736,53 @@ exit 0'
   state_teardown
 }
 
+test_claim_marks_issue_in_progress() {
+  state_setup
+  local args_file="$STATE_DIR/issue_edit_args"
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_EDIT_ARGS"
+  exit 0
+fi
+exit 1'
+  export FAKE_EDIT_ARGS="$args_file"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_claim 10 ticket/10-alpha "$WT_PARENT/10-alpha"
+  assert_contains "claim removes ready-for-agent" "--remove-label ready-for-agent" "$(cat "$args_file")"
+  assert_contains "claim adds in-progress" "--add-label in-progress" "$(cat "$args_file")"
+  assert_eq "claim records state entry" "1" "$(orchestrator_state_active_count "$TEST_STATE")"
+  assert_eq "state entry phase is implementing" "implementing" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  unset FAKE_EDIT_ARGS
+  state_teardown
+}
+
+test_claim_failure_leaves_no_state() {
+  state_setup
+  fake_command gh 'exit 1'
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_claim 10 ticket/10-alpha "$WT_PARENT/10-alpha" >/dev/null 2>&1; then
+    fail "claim fails when gh issue edit fails"
+  else
+    pass "claim fails when gh issue edit fails"
+  fi
+  assert_eq "failed claim leaves no state entry" "0" "$(orchestrator_state_active_count "$TEST_STATE")"
+  state_teardown
+}
+
+test_poll_once_does_not_cleanup_preexisting_worktree() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  printf "[{\"number\":10,\"title\":\"Alpha\"}]\n"
+elif [[ "$1" == "api" ]]; then
+  printf "0\n"
+fi
+exit 0'
+  fake_command git 'exit 0'
+  local worktree="$WT_PARENT/10-alpha"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once >/dev/null 2>&1
+  assert_eq "pre-existing worktree survives failed implementation" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "failed claim leaves no state entry" "0" "$(jq 'length' "$TEST_STATE" 2>/dev/null || echo 0)"
+  state_teardown
+}
+
 test_poll_once_cleans_up_worktree_after_failed_implement() {
   state_setup
   fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
@@ -869,6 +916,9 @@ test_poll_once_respects_concurrency_cap
 test_poll_once_skips_when_cap_full
 test_poll_once_removes_entry_on_failed_implement
 test_poll_once_cleans_up_worktree_after_failed_implement
+test_poll_once_does_not_cleanup_preexisting_worktree
+test_claim_marks_issue_in_progress
+test_claim_failure_leaves_no_state
 test_cli_once
 fake_teardown
 

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -63,6 +63,41 @@ fake_teardown() {
   FAKE_DIR=""
 }
 
+# Fake a successful worktree-add (creates the dir) and npm ci.
+fake_worktree_npm() {
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+fi
+exit 0'
+  fake_command npm 'exit 0'
+}
+
+# Fake the commands the implementation pipeline invokes: git worktree add,
+# npm ci, opencode run + session list, and gh pr list / issue comment. The
+# gh fake delegates everything else to the caller-provided body.
+fake_pipeline() {
+  local gh_body="$1" pr_number="${2:-100}"
+  fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"list\" ]]; then
+  printf \"[{\\\"number\\\":$pr_number}]\n\"
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"comment\" ]]; then
+  exit 0
+else
+  $gh_body
+fi
+exit 0"
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+fi
+exit 0'
+  fake_command npm 'exit 0'
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_10\",\"title\":\"carbotracker-ticket-10\",\"created\":1},{\"id\":\"ses_42\",\"title\":\"carbotracker-ticket-42\",\"created\":2}]\n"
+fi
+exit 0'
+}
+
 STATE_DIR=""
 TEST_STATE=""
 WT_PARENT=""
@@ -133,6 +168,62 @@ test_state_has_ticket() {
   else
     pass "has_ticket false for unclaimed ticket"
   fi
+  state_teardown
+}
+
+test_state_complete_updates_entry() {
+  state_setup
+  orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$WT_PARENT/123-foo"
+  orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local entry
+  entry="$(jq '.[0]' "$TEST_STATE")"
+  assert_eq "complete stores session id" "ses_abc" "$(jq -r '.sessionId' <<<"$entry")"
+  assert_eq "complete stores pr number" "456" "$(jq -r '.prNumber' <<<"$entry")"
+  assert_eq "complete transitions phase to awaiting review" "awaiting review" "$(jq -r '.phase' <<<"$entry")"
+  assert_eq "complete leaves only the matching entry touched" "1" "$(jq 'length' "$TEST_STATE")"
+  state_teardown
+}
+
+test_state_complete_with_missing_values() {
+  state_setup
+  orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$WT_PARENT/123-foo"
+  orchestrator_state_complete "$TEST_STATE" 123 "" ""
+  local entry
+  entry="$(jq '.[0]' "$TEST_STATE")"
+  assert_eq "missing session id stored as null" "null" "$(jq -r '.sessionId' <<<"$entry")"
+  assert_eq "missing pr number stored as null" "null" "$(jq -r '.prNumber' <<<"$entry")"
+  assert_eq "phase still transitions without values" "awaiting review" "$(jq -r '.phase' <<<"$entry")"
+  state_teardown
+}
+
+test_state_complete_updates_only_matching_ticket() {
+  state_setup
+  orchestrator_state_add "$TEST_STATE" 1 ticket/1-a "$WT_PARENT/1-a"
+  orchestrator_state_add "$TEST_STATE" 2 ticket/2-b "$WT_PARENT/2-b"
+  orchestrator_state_complete "$TEST_STATE" 2 ses_2 22
+  assert_eq "other entry keeps session null" "null" "$(jq -r '.[0].sessionId' "$TEST_STATE")"
+  assert_eq "other entry keeps phase implementing" "implementing" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_eq "matching entry gets session" "ses_2" "$(jq -r '.[1].sessionId' "$TEST_STATE")"
+  assert_eq "matching entry gets pr number" "22" "$(jq -r '.[1].prNumber' "$TEST_STATE")"
+  state_teardown
+}
+
+test_state_remove_removes_entry() {
+  state_setup
+  orchestrator_state_add "$TEST_STATE" 1 ticket/1-a "$WT_PARENT/1-a"
+  orchestrator_state_add "$TEST_STATE" 2 ticket/2-b "$WT_PARENT/2-b"
+  orchestrator_state_remove "$TEST_STATE" 1
+  assert_eq "remove drops the entry" "2" "$(jq -r '.[0].ticket' "$TEST_STATE")"
+  assert_eq "remove leaves the rest" "1" "$(jq 'length' "$TEST_STATE")"
+  state_teardown
+}
+
+test_state_active_count_counts_implementing_only() {
+  state_setup
+  orchestrator_state_add "$TEST_STATE" 1 ticket/1-a "$WT_PARENT/1-a"
+  orchestrator_state_add "$TEST_STATE" 2 ticket/2-b "$WT_PARENT/2-b"
+  orchestrator_state_complete "$TEST_STATE" 2 ses_2 22
+  assert_eq "completed tickets do not count toward cap" "1" "$(orchestrator_state_active_count "$TEST_STATE")"
   state_teardown
 }
 
@@ -274,7 +365,7 @@ exit 1'
 
 test_poll_once_claims_candidates() {
   state_setup
-  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  fake_pipeline 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
   printf "[{\"number\":10,\"title\":\"Alpha\"},{\"number\":42,\"title\":\"Beta\"}]\n"
 elif [[ "$1" == "api" ]]; then
   printf "no native dependencies\n" >&2
@@ -284,22 +375,23 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
     10) printf "Alpha body\n" ;;
     42) printf "Beta body\n" ;;
   esac
-fi
-exit 0'
+fi'
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
   assert_eq "claims all unblocked candidates" "2" "$(jq 'length' "$TEST_STATE")"
   assert_eq "claims first ticket number" "10" "$(jq -r '.[0].ticket' "$TEST_STATE")"
   assert_eq "claims second ticket number" "42" "$(jq -r '.[1].ticket' "$TEST_STATE")"
+  assert_eq "implemented tickets transition to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
   assert_contains "logs discovery" "poll: 2 candidate(s)" "$output"
-  assert_contains "logs claim transition" "claim #10 (Alpha): phase implementing" "$output"
+  assert_contains "logs claim transition" "claim #10: phase implementing" "$output"
   assert_contains "logs branch construction" "branch ticket/10-alpha" "$output"
+  assert_contains "logs completed transition" "completed #10: session ses_10, PR #100" "$output"
   state_teardown
 }
 
 test_poll_once_skips_claimed() {
   state_setup
-  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  fake_pipeline 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
   printf "[{\"number\":10,\"title\":\"Alpha\"},{\"number\":42,\"title\":\"Beta\"}]\n"
 elif [[ "$1" == "api" ]]; then
   printf "no native dependencies\n" >&2
@@ -309,8 +401,7 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
     10) printf "Alpha body\n" ;;
     42) printf "Beta body\n" ;;
   esac
-fi
-exit 0'
+fi'
   orchestrator_state_add "$TEST_STATE" 10 ticket/10-alpha "$WT_PARENT/10-alpha"
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
@@ -321,15 +412,14 @@ exit 0'
 
 test_poll_once_skips_blocked() {
   state_setup
-  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  fake_pipeline 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
   printf "[{\"number\":10,\"title\":\"Alpha\"},{\"number\":42,\"title\":\"Beta\"}]\n"
 elif [[ "$1" == "api" ]]; then
   case "$2" in
     */10/*) printf "1\n" ;;
     */42/*) printf "0\n" ;;
   esac
-fi
-exit 0'
+fi'
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
   assert_eq "only claims unblocked candidate" "1" "$(jq 'length' "$TEST_STATE")"
@@ -340,16 +430,16 @@ exit 0'
 
 test_poll_once_respects_concurrency_cap() {
   state_setup
-  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  fake_pipeline 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
   printf "[{\"number\":10,\"title\":\"Alpha\"},{\"number\":42,\"title\":\"Beta\"}]\n"
 elif [[ "$1" == "api" ]]; then
   printf "0\n"
-fi
-exit 0'
+fi'
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once)"
   assert_eq "cap limits claims to first ticket" "1" "$(jq 'length' "$TEST_STATE")"
   assert_eq "cap claims the FIFO-first ticket" "10" "$(jq -r '.[0].ticket' "$TEST_STATE")"
+  assert_eq "implemented ticket reaches awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
   assert_contains "logs cap reached" "concurrency cap 1 reached" "$output"
   state_teardown
 }
@@ -367,6 +457,206 @@ exit 0'
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once)"
   assert_eq "no new claims at full cap" "1" "$(jq 'length' "$TEST_STATE")"
   assert_contains "logs cap reached" "concurrency cap 1 reached" "$output"
+  state_teardown
+}
+
+test_opencode_session_id_filters_by_title() {
+  fake_command opencode 'printf "[{\"id\":\"ses_old\",\"title\":\"carbotracker-ticket-10\",\"created\":1},{\"id\":\"ses_new\",\"title\":\"carbotracker-ticket-10\",\"created\":2},{\"id\":\"ses_other\",\"title\":\"other work\",\"created\":3}]\n"
+exit 0'
+  assert_eq "session id filters by title and picks newest" "ses_new" "$(orchestrator_opencode_session_id carbotracker-ticket-10)"
+}
+
+test_opencode_session_id_no_match() {
+  fake_command opencode 'printf "[{\"id\":\"ses_a\",\"title\":\"other work\",\"created\":1}]\n"
+exit 0'
+  assert_eq "session id empty when no title matches" "" "$(orchestrator_opencode_session_id carbotracker-ticket-99)"
+}
+
+test_pr_number_for_branch() {
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[{\"number\":40},{\"number\":42}]\n"
+fi
+exit 0'
+  assert_eq "pr number returns newest pr for branch" "42" "$(orchestrator_pr_number_for_branch ticket/10-alpha)"
+}
+
+test_pr_number_for_branch_missing() {
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[]\n"
+fi
+exit 0'
+  assert_eq "pr number empty when no pr exists" "" "$(orchestrator_pr_number_for_branch ticket/10-alpha)"
+}
+
+test_implement_runs_full_pipeline() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[{\"number\":42}]\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_COMMENT_FILE"
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  printf "%s\n" "$*" > "$FAKE_OPENCODE_ARGS"
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_abc\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_COMMENT_FILE="$STATE_DIR/comment"
+  export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree"
+  assert_eq "worktree dir created" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "opencode run invoked with title and issue prompt" "run --auto --title carbotracker-ticket-10 /implement the issue is 10" "$(cat "$FAKE_OPENCODE_ARGS")"
+  assert_eq "state session id stored" "ses_abc" "$(jq -r '.[0].sessionId' "$TEST_STATE")"
+  assert_eq "state pr number stored" "42" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  assert_eq "phase transitions to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_contains "issue commented with pr number" "Started implementation. PR #42 created." "$(cat "$FAKE_COMMENT_FILE")"
+  unset FAKE_COMMENT_FILE FAKE_OPENCODE_ARGS
+  state_teardown
+}
+
+test_implement_fails_when_worktree_fails() {
+  state_setup
+  fake_command git 'if [[ "$1" == "worktree" ]]; then
+  exit 1
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+    fail "implement fails when worktree creation fails"
+  else
+    pass "implement fails when worktree creation fails"
+  fi
+  state_teardown
+}
+
+test_implement_fails_when_npm_ci_fails() {
+  state_setup
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+fi
+exit 0'
+  fake_command npm 'exit 1'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+    fail "implement fails when npm ci fails"
+  else
+    pass "implement fails when npm ci fails"
+  fi
+  state_teardown
+}
+
+test_implement_fails_when_opencode_fails() {
+  state_setup
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+fi
+exit 0'
+  fake_command npm 'exit 0'
+  fake_command opencode 'exit 1'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+    fail "implement fails when opencode run fails"
+  else
+    pass "implement fails when opencode run fails"
+  fi
+  state_teardown
+}
+
+test_implement_no_pr_skips_comment() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[]\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_COMMENT_FILE"
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_abc\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_COMMENT_FILE="$STATE_DIR/comment"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree")"
+  assert_eq "pr number stored as null when no pr" "null" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  assert_eq "no comment file written" "no" "$([[ -f "$FAKE_COMMENT_FILE" ]] && echo yes || echo no)"
+  assert_contains "logs warning about missing pr" "no PR found" "$output"
+  unset FAKE_COMMENT_FILE
+  state_teardown
+}
+
+test_implement_no_session_stores_null() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[{\"number\":42}]\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null
+  assert_eq "session id stored as null when not found" "null" "$(jq -r '.[0].sessionId' "$TEST_STATE")"
+  assert_eq "pr number still stored" "42" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  state_teardown
+}
+
+test_poll_once_removes_entry_on_failed_implement() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  printf "[{\"number\":10,\"title\":\"Alpha\"}]\n"
+elif [[ "$1" == "api" ]]; then
+  printf "0\n"
+fi
+exit 0'
+  fake_command git 'if [[ "$1" == "worktree" ]]; then
+  exit 1
+fi
+exit 0'
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
+  assert_eq "failed implementation leaves no state entry" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "logs removal of failed ticket" "removed #10 from state" "$output"
+  state_teardown
+}
+
+test_poll_once_cleans_up_worktree_after_failed_implement() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  printf "[{\"number\":10,\"title\":\"Alpha\"}]\n"
+elif [[ "$1" == "api" ]]; then
+  printf "0\n"
+fi
+exit 0'
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+elif [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+  rm -rf "$3" "$4"
+fi
+exit 0'
+  fake_command npm 'exit 1'
+  local worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once >/dev/null
+  assert_eq "worktree removed after failed implementation" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
   state_teardown
 }
 
@@ -406,7 +696,7 @@ test_cli_help() {
 
 test_cli_once() {
   state_setup
-  fake_command gh 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  fake_pipeline 'if [[ "$1" == "issue" && "$2" == "list" ]]; then
   printf "[{\"number\":10,\"title\":\"Alpha\"}]\n"
 elif [[ "$1" == "api" ]]; then
   printf "no native dependencies\n" >&2
@@ -415,11 +705,11 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
   case "$3" in
     10) printf "Alpha body\n" ;;
   esac
-fi
-exit 0'
+fi'
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" bash "$ROOT/tools/ct-orchestrator.sh" once)"
   assert_eq "once mode claims the ticket" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "once mode completes the ticket" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
   assert_contains "once mode logs discovery" "poll:" "$output"
   state_teardown
 }
@@ -441,6 +731,11 @@ test_state_loaded_but_empty_file() {
 
 test_state_load_missing
 test_state_loaded_but_empty_file
+test_state_complete_updates_entry
+test_state_complete_with_missing_values
+test_state_complete_updates_only_matching_ticket
+test_state_remove_removes_entry
+test_state_active_count_counts_implementing_only
 
 test_config_defaults
 test_config_file_parsing
@@ -457,11 +752,23 @@ test_issue_unblocked_when_blocker_closed
 test_issue_blocked_when_blocker_state_unresolvable
 test_issue_blocked_via_blocked_by_section
 test_body_blocker_numbers_stops_at_next_section
+test_opencode_session_id_filters_by_title
+test_opencode_session_id_no_match
+test_pr_number_for_branch
+test_pr_number_for_branch_missing
+test_implement_runs_full_pipeline
+test_implement_fails_when_worktree_fails
+test_implement_fails_when_npm_ci_fails
+test_implement_fails_when_opencode_fails
+test_implement_no_pr_skips_comment
+test_implement_no_session_stores_null
 test_poll_once_claims_candidates
 test_poll_once_skips_claimed
 test_poll_once_skips_blocked
 test_poll_once_respects_concurrency_cap
 test_poll_once_skips_when_cap_full
+test_poll_once_removes_entry_on_failed_implement
+test_poll_once_cleans_up_worktree_after_failed_implement
 test_cli_once
 fake_teardown
 

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -63,10 +63,13 @@ fake_teardown() {
   FAKE_DIR=""
 }
 
-# Fake a successful worktree-add (creates the dir) and npm ci.
+# Fake a successful worktree-add (creates the dir) and npm ci. When
+# FAKE_GIT_PUSH_FILE is set, the push invocation is captured to it.
 fake_worktree_npm() {
   fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
   mkdir -p "$3"
+elif [[ "$1" == "push" && -n "${FAKE_GIT_PUSH_FILE:-}" ]]; then
+  printf "%s\n" "$*" > "$FAKE_GIT_PUSH_FILE"
 fi
 exit 0'
   fake_command npm 'exit 0'
@@ -377,7 +380,7 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
   esac
 fi'
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once 2>&1)"
   assert_eq "claims all unblocked candidates" "2" "$(jq 'length' "$TEST_STATE")"
   assert_eq "claims first ticket number" "10" "$(jq -r '.[0].ticket' "$TEST_STATE")"
   assert_eq "claims second ticket number" "42" "$(jq -r '.[1].ticket' "$TEST_STATE")"
@@ -404,7 +407,7 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
 fi'
   orchestrator_state_add "$TEST_STATE" 10 ticket/10-alpha "$WT_PARENT/10-alpha"
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once 2>&1)"
   assert_eq "does not re-claim an active ticket" "2" "$(jq 'length' "$TEST_STATE")"
   assert_contains "logs skip of claimed ticket" "skip #10 (Alpha): already claimed" "$output"
   state_teardown
@@ -421,7 +424,7 @@ elif [[ "$1" == "api" ]]; then
   esac
 fi'
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once 2>&1)"
   assert_eq "only claims unblocked candidate" "1" "$(jq 'length' "$TEST_STATE")"
   assert_eq "claims the unblocked ticket" "42" "$(jq -r '.[0].ticket' "$TEST_STATE")"
   assert_contains "logs skip of blocked ticket" "skip #10 (Alpha): blocked" "$output"
@@ -436,7 +439,7 @@ elif [[ "$1" == "api" ]]; then
   printf "0\n"
 fi'
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once 2>&1)"
   assert_eq "cap limits claims to first ticket" "1" "$(jq 'length' "$TEST_STATE")"
   assert_eq "cap claims the FIFO-first ticket" "10" "$(jq -r '.[0].ticket' "$TEST_STATE")"
   assert_eq "implemented ticket reaches awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
@@ -454,7 +457,7 @@ fi
 exit 0'
   orchestrator_state_add "$TEST_STATE" 1 ticket/1-existing "$WT_PARENT/1-existing"
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=1 orchestrator_poll_once 2>&1)"
   assert_eq "no new claims at full cap" "1" "$(jq 'length' "$TEST_STATE")"
   assert_contains "logs cap reached" "concurrency cap 1 reached" "$output"
   state_teardown
@@ -507,15 +510,109 @@ exit 0'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
   export FAKE_COMMENT_FILE="$STATE_DIR/comment"
   export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  export FAKE_GIT_PUSH_FILE="$STATE_DIR/git_push"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree"
   assert_eq "worktree dir created" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
   assert_eq "opencode run invoked with title and issue prompt" "run --auto --title carbotracker-ticket-10 /implement the issue is 10" "$(cat "$FAKE_OPENCODE_ARGS")"
+  assert_contains "branch pushed to origin" "push -u origin ticket/10-alpha" "$(cat "$FAKE_GIT_PUSH_FILE")"
   assert_eq "state session id stored" "ses_abc" "$(jq -r '.[0].sessionId' "$TEST_STATE")"
   assert_eq "state pr number stored" "42" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
   assert_eq "phase transitions to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
   assert_contains "issue commented with pr number" "Started implementation. PR #42 created." "$(cat "$FAKE_COMMENT_FILE")"
-  unset FAKE_COMMENT_FILE FAKE_OPENCODE_ARGS
+  unset FAKE_COMMENT_FILE FAKE_OPENCODE_ARGS FAKE_GIT_PUSH_FILE
+  state_teardown
+}
+
+test_implement_opens_pr_when_none_exists() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  local n
+  n="$(cat "$FAKE_PR_COUNT" 2>/dev/null || echo 0)"
+  if [[ "$n" == "0" ]]; then
+    printf "1\n" > "$FAKE_PR_COUNT"
+    printf "[]\n"
+  else
+    printf "[{\"number\":50}]\n"
+  fi
+elif [[ "$1" == "pr" && "$2" == "create" ]]; then
+  printf "%s\n" "$*" > "$FAKE_PR_CREATE_ARGS"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_1\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_PR_COUNT="$STATE_DIR/pr_count"
+  export FAKE_PR_CREATE_ARGS="$STATE_DIR/pr_create"
+  printf '0\n' > "$FAKE_PR_COUNT"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null
+  assert_contains "creates pr with base main" "--base main" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_contains "creates pr with head branch" "--head ticket/10-alpha" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_contains "creates pr with title" "Implement Alpha (#10)" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_eq "stores created pr number" "50" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  unset FAKE_PR_COUNT FAKE_PR_CREATE_ARGS
+  state_teardown
+}
+
+test_implement_fails_when_push_fails() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[]\n"
+fi
+exit 0'
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+elif [[ "$1" == "push" ]]; then
+  exit 1
+fi
+exit 0'
+  fake_command npm 'exit 0'
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"s\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
+    fail "implement fails when git push fails"
+  else
+    pass "implement fails when git push fails"
+  fi
+  state_teardown
+}
+
+test_implement_fails_when_pr_create_fails() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[]\n"
+elif [[ "$1" == "pr" && "$2" == "create" ]]; then
+  exit 1
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"s\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
+    fail "implement fails when gh pr create fails"
+  else
+    pass "implement fails when gh pr create fails"
+  fi
   state_teardown
 }
 
@@ -527,7 +624,7 @@ fi
 exit 0'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
     fail "implement fails when worktree creation fails"
   else
     pass "implement fails when worktree creation fails"
@@ -544,7 +641,7 @@ exit 0'
   fake_command npm 'exit 1'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
     fail "implement fails when npm ci fails"
   else
     pass "implement fails when npm ci fails"
@@ -562,7 +659,7 @@ exit 0'
   fake_command opencode 'exit 1'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null 2>&1; then
+  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
     fail "implement fails when opencode run fails"
   else
     pass "implement fails when opencode run fails"
@@ -589,7 +686,7 @@ exit 0'
   export FAKE_COMMENT_FILE="$STATE_DIR/comment"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree")"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" 2>&1)"
   assert_eq "pr number stored as null when no pr" "null" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
   assert_eq "no comment file written" "no" "$([[ -f "$FAKE_COMMENT_FILE" ]] && echo yes || echo no)"
   assert_contains "logs warning about missing pr" "no PR found" "$output"
@@ -614,7 +711,7 @@ fi
 exit 0'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "$branch" "$worktree" >/dev/null
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null
   assert_eq "session id stored as null when not found" "null" "$(jq -r '.[0].sessionId' "$TEST_STATE")"
   assert_eq "pr number still stored" "42" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
   state_teardown
@@ -633,7 +730,7 @@ exit 0'
 fi
 exit 0'
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" ORCHESTRATOR_CONCURRENCY_CAP=3 orchestrator_poll_once 2>&1)"
   assert_eq "failed implementation leaves no state entry" "0" "$(jq 'length' "$TEST_STATE")"
   assert_contains "logs removal of failed ticket" "removed #10 from state" "$output"
   state_teardown
@@ -707,7 +804,7 @@ elif [[ "$1" == "issue" && "$2" == "view" ]]; then
   esac
 fi'
   local output
-  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" bash "$ROOT/tools/ct-orchestrator.sh" once)"
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" bash "$ROOT/tools/ct-orchestrator.sh" once 2>&1)"
   assert_eq "once mode claims the ticket" "1" "$(jq 'length' "$TEST_STATE")"
   assert_eq "once mode completes the ticket" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
   assert_contains "once mode logs discovery" "poll:" "$output"
@@ -762,6 +859,9 @@ test_implement_fails_when_npm_ci_fails
 test_implement_fails_when_opencode_fails
 test_implement_no_pr_skips_comment
 test_implement_no_session_stores_null
+test_implement_opens_pr_when_none_exists
+test_implement_fails_when_push_fails
+test_implement_fails_when_pr_create_fails
 test_poll_once_claims_candidates
 test_poll_once_skips_claimed
 test_poll_once_skips_blocked


### PR DESCRIPTION
Wires the real ticket-to-PR pipeline into the orchestrator poll cycle:

- Claims a ticket, derives branch ticket/<issue>-<slug> and worktree
  path, then creates the worktree from origin/main (ct_worktree_add)
- Runs npm ci --prefer-offline --no-audit --no-fund in the worktree
- Launches opencode run --auto --title carbotracker-ticket-<N> with the
  /implement prompt, in the worktree directory
- After opencode exits, resolves the session id by title from
  opencode session list --format json and the PR number from
  gh pr list --head <branch>
- Writes session id + PR number into the state file and transitions the
  ticket to the awaiting review phase, then comments on the issue
- Failed implementations un-claim the ticket and clean up the worktree
  and branch so the ticket can be retried; the concurrency cap counts
  only in-flight (implementing) tickets
- ct_worktree_create now delegates to a reusable ct_worktree_add seam
- Adds WorkingDirectory to the systemd unit so git commands run in the
  repo

TDD: new tests for state complete/remove, session/PR lookups, the full
implementation pipeline, failure cleanup, and updated poll-cycle tests.
