### PR TITLE
Merge detection, cleanup, and issue closure (#220)

### DIFF
--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -314,8 +314,22 @@ orchestrator_merge_poll() {
         fi
         ;;
       CLOSED)
-        orchestrator_log "PR #$pr_number closed without merge for #$number; pruning worktree"
-        orchestrator_prune_ticket "$number" "$branch" "$worktree"
+        # The PR was closed without merging: the work is rejected and the
+        # ticket is no longer in flight. Prune the worktree/branch, then
+        # escalate the issue to human triage — drop in-progress, add
+        # needs-triage, and leave a comment naming the closed PR. The entry is
+        # removed only once the escalation lands, so a transient gh failure
+        # retries next poll instead of stranding an un-labelled issue.
+        orchestrator_log "PR #$pr_number closed without merge for #$number; pruning worktree and escalating to triage"
+        if gh issue edit "$number" --remove-label "$ORCHESTRATOR_IN_PROGRESS_LABEL" --add-label needs-triage \
+          && gh issue comment "$number" --body "PR #$pr_number was closed without merging. Escalated to needs-triage for human review.
+---
+_Created by carbotracker's agent skills._"; then
+          orchestrator_prune_ticket "$number" "$branch" "$worktree"
+          orchestrator_log "escalated #$number to needs-triage and pruned worktree"
+        else
+          orchestrator_log "WARNING: failed to escalate #$number; keeping entry to retry next poll"
+        fi
         ;;
       OPEN)
         orchestrator_log "merge #$number: PR #$pr_number still open"

--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -158,6 +158,11 @@ orchestrator_pr_number_for_branch() {
     | jq -r 'sort_by(.number) | reverse | .[0].number // empty' 2>/dev/null || true
 }
 
+orchestrator_pr_state() {
+  local pr="$1"
+  gh pr view "$pr" --json state --jq .state 2>/dev/null || true
+}
+
 orchestrator_pr_latest_comment_at() {
   local pr="$1" me inline reviews general latest
   # Review surfaces: inline threads (pulls/<n>/comments), top-level review
@@ -228,6 +233,10 @@ _Created by carbotracker's agent skills._"
   return 1
 }
 
+orchestrator_awaiting_review_entries() {
+  orchestrator_state_load "$ORCHESTRATOR_STATE_FILE" | jq -c '.[] | select(.phase == "awaiting review")'
+}
+
 orchestrator_review_poll() {
   local line number pr_number session_id worktree last_comment_at latest notice_posted
   while IFS= read -r line; do
@@ -270,7 +279,52 @@ _Created by carbotracker's agent skills._"
     fi
     orchestrator_log "review #$number: new comment on PR #$pr_number (latest $latest, last known ${last_comment_at:-<none>})"
     orchestrator_review_round "$number" "$session_id" "$pr_number" "$worktree" || true
-  done < <(orchestrator_state_load "$ORCHESTRATOR_STATE_FILE" | jq -c '.[] | select(.phase == "awaiting review")')
+  done < <(orchestrator_awaiting_review_entries)
+}
+
+orchestrator_prune_ticket() {
+  local number="$1" branch="$2" worktree="$3"
+  orchestrator_cleanup_worktree "$worktree" "$branch"
+  orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+  orchestrator_log "pruned #$number: worktree removed, branch deleted, removed from state"
+}
+
+orchestrator_merge_poll() {
+  local line number pr_number branch worktree state
+  while IFS= read -r line; do
+    number="$(printf '%s' "$line" | jq -r '.ticket')"
+    pr_number="$(printf '%s' "$line" | jq -r '.prNumber')"
+    branch="$(printf '%s' "$line" | jq -r '.branch')"
+    worktree="$(printf '%s' "$line" | jq -r '.worktree')"
+
+    if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+      orchestrator_log "skip merge #$number: no PR recorded"
+      continue
+    fi
+
+    state="$(orchestrator_pr_state "$pr_number")"
+    case "$state" in
+      MERGED)
+        orchestrator_log "merge detected: PR #$pr_number merged for #$number; closing issue"
+        if gh issue close "$number" --comment "PR #$pr_number merged. Issue closed."; then
+          orchestrator_prune_ticket "$number" "$branch" "$worktree"
+          orchestrator_log "closed issue #$number with merge comment"
+        else
+          orchestrator_log "WARNING: failed to close issue #$number; keeping entry to retry next poll"
+        fi
+        ;;
+      CLOSED)
+        orchestrator_log "PR #$pr_number closed without merge for #$number; pruning worktree"
+        orchestrator_prune_ticket "$number" "$branch" "$worktree"
+        ;;
+      OPEN)
+        orchestrator_log "merge #$number: PR #$pr_number still open"
+        ;;
+      *)
+        orchestrator_log "WARNING: could not determine state of PR #$pr_number for #$number"
+        ;;
+    esac
+  done < <(orchestrator_awaiting_review_entries)
 }
 
 orchestrator_push_and_open_pr() {
@@ -396,6 +450,7 @@ orchestrator_poll_once() {
     fi
   done < <(printf '%s' "$candidates" | jq -c '.[]')
 
+  orchestrator_merge_poll
   orchestrator_review_poll
 }
 

--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -306,7 +306,8 @@ orchestrator_merge_poll() {
     case "$state" in
       MERGED)
         orchestrator_log "merge detected: PR #$pr_number merged for #$number; closing issue"
-        if gh issue close "$number" --comment "PR #$pr_number merged. Issue closed."; then
+        if gh issue edit "$number" --remove-label "$ORCHESTRATOR_IN_PROGRESS_LABEL" \
+          && gh issue close "$number" --comment "PR #$pr_number merged. Issue closed."; then
           orchestrator_prune_ticket "$number" "$branch" "$worktree"
           orchestrator_log "closed issue #$number with merge comment"
         else

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -4,11 +4,11 @@
 `ready-for-agent` tickets, claims them up to a concurrency cap, and runs each
 one through a full implementation cycle — worktree, dependency install,
 headless `opencode`, and finally a pushed branch with a pull request. Once a
-PR is up it also runs the **review loop**: every poll it checks awaiting-review
-PRs for new comments and, when it finds one, resumes the original opencode
-session with `/review-comments` so the agent answers the review and pushes
-updates. It runs as a systemd user service (see
-`carbotracker-orchestrator.service`).
+PR is up it runs the **merge poll** (detecting merged or closed PRs and
+cleaning up) and the **review loop**: every poll it checks awaiting-review PRs
+for new comments and, when it finds one, resumes the original opencode session
+with `/review-comments` so the agent answers the review and pushes updates. It
+runs as a systemd user service (see `carbotracker-orchestrator.service`).
 
 ## Lifecycle
 
@@ -21,7 +21,8 @@ stateDiagram-v2
     implementing --> [*]: failure, un-claim and clean up
     awaiting_review --> review_round: new comment on PR (newer than lastCommentAt)
     review_round --> awaiting_review: /review-comments succeeds or a retry fails
-    awaiting_review --> [*]: human merges the PR
+    awaiting_review --> [*]: merge poll sees PR merged, closes issue
+    awaiting_review --> [*]: merge poll sees PR closed without merge
 ```
 
 `implementing` means the orchestrator is actively running a session for the
@@ -33,6 +34,26 @@ add `in-progress`) and in the local state file. The label flip is what makes
 the claim visible to humans and atomic against parallel orchestrators — once
 an issue drops `ready-for-agent` it stops matching the candidate query, so a
 second daemon cannot claim it.
+
+## Merge detection and cleanup
+
+Each poll, before the review loop, the orchestrator walks every state entry in
+`awaiting review` that has a PR number and checks the PR's state via
+`gh pr view <n> --json state`:
+
+- **`MERGED`** — the human merged the PR. The orchestrator closes the issue
+  with the comment "PR #&lt;n&gt; merged. Issue closed.", prunes the worktree
+  and branch, and removes the entry from the state file. The lifecycle
+  (issue → PR → merged → closed) is complete and the ticket no longer occupies
+  a concurrency slot. If `gh issue close` fails, the entry is **kept** so the
+  merge is re-detected and the close retried on the next poll — the closure
+  is never silently dropped.
+- **`CLOSED`** — the PR was closed without merging. The orchestrator prunes
+  the worktree and branch and removes the entry from the state file, but does
+  not touch the issue.
+- **`OPEN`** — still awaiting review, nothing to do.
+- **anything else / gh failure** — the state query failed; the entry is kept
+  so the merge is retried on the next poll.
 
 ## Review loop
 
@@ -121,8 +142,15 @@ flowchart TD
     K --> L[state: sessionId + prNumber, phase awaiting review]
     L --> M[gh issue comment: Started implementation. PR #N created.]
     F -- failure --> N[un-claim + remove worktree/branch, retry next poll]
-    M --> O[review loop: walk awaiting-review entries]
-    O --> P[gh api pulls/N/comments + pulls/N/reviews + issues/N/comments → newest non-bot timestamp]
+    M --> O[merge poll: walk awaiting-review entries]
+    O --> P0[gh pr view n → state]
+    P0 -- MERGED --> P1[close issue: PR #n merged. Issue closed. → prune worktree/branch, remove from state]
+    P1 -- close failed --> O
+    P0 -- CLOSED --> P2[prune worktree/branch, remove from state]
+    P0 -- OPEN --> P3
+    P2 --> O
+    P3[review loop: walk remaining awaiting-review entries]
+    P3 --> P[gh api pulls/N/comments + pulls/N/reviews + issues/N/comments → newest non-bot timestamp]
     P --> Q{newer than lastCommentAt?}
     Q -- no --> O
     Q -- yes --> R[opencode run --auto --session S /review-comments on PR #N]
@@ -133,7 +161,8 @@ flowchart TD
 ```
 
 The orchestrator never resolves review threads or merges — after the PR is
-opened it hands off to a human.
+opened it hands off to a human, and on merge (or close without merge) the
+merge poll prunes the worktree and closes the issue.
 
 ## Configuration
 

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -48,9 +48,12 @@ Each poll, before the review loop, the orchestrator walks every state entry in
   a concurrency slot. If `gh issue close` fails, the entry is **kept** so the
   merge is re-detected and the close retried on the next poll — the closure
   is never silently dropped.
-- **`CLOSED`** — the PR was closed without merging. The orchestrator prunes
-  the worktree and branch and removes the entry from the state file, but does
-  not touch the issue.
+- **`CLOSED`** — the PR was closed without merging: the work is rejected. The
+  orchestrator prunes the worktree and branch, then escalates the issue to a
+  human — drops `in-progress`, adds `needs-triage`, and leaves a comment
+  naming the closed PR. The entry is removed only once the escalation lands,
+  so a transient `gh` failure retries next poll instead of stranding an
+  un-labelled issue.
 - **`OPEN`** — still awaiting review, nothing to do.
 - **anything else / gh failure** — the state query failed; the entry is kept
   so the merge is retried on the next poll.
@@ -146,8 +149,9 @@ flowchart TD
     O --> P0[gh pr view n → state]
     P0 -- MERGED --> P1[close issue: PR #n merged. Issue closed. → prune worktree/branch, remove from state]
     P1 -- close failed --> O
-    P0 -- CLOSED --> P2[prune worktree/branch, remove from state]
+    P0 -- CLOSED --> P2[escalate: drop in-progress, add needs-triage, comment → prune worktree/branch, remove from state]
     P0 -- OPEN --> P3
+    P2 -- escalate failed --> O
     P2 --> O
     P3[review loop: walk remaining awaiting-review entries]
     P3 --> P[gh api pulls/N/comments + pulls/N/reviews + issues/N/comments → newest non-bot timestamp]

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -41,13 +41,13 @@ Each poll, before the review loop, the orchestrator walks every state entry in
 `awaiting review` that has a PR number and checks the PR's state via
 `gh pr view <n> --json state`:
 
-- **`MERGED`** — the human merged the PR. The orchestrator closes the issue
-  with the comment "PR #&lt;n&gt; merged. Issue closed.", prunes the worktree
-  and branch, and removes the entry from the state file. The lifecycle
-  (issue → PR → merged → closed) is complete and the ticket no longer occupies
-  a concurrency slot. If `gh issue close` fails, the entry is **kept** so the
-  merge is re-detected and the close retried on the next poll — the closure
-  is never silently dropped.
+- **`MERGED`** — the human merged the PR. The orchestrator drops the
+  `in-progress` label, closes the issue with the comment
+  "PR #&lt;n&gt; merged. Issue closed.", prunes the worktree and branch, and
+  removes the entry from the state file. The lifecycle (issue → PR → merged →
+  closed) is complete and the ticket no longer occupies a concurrency slot. If
+  the close fails, the entry is **kept** so the merge is re-detected and the
+  close retried on the next poll — the closure is never silently dropped.
 - **`CLOSED`** — the PR was closed without merging: the work is rejected. The
   orchestrator prunes the worktree and branch, then escalates the issue to a
   human — drops `in-progress`, adds `needs-triage`, and leaves a comment

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -144,6 +144,30 @@ fi
 exit 1"
 }
 
+# Fake gh for the merge poll: `pr view` returns the PR state passed as $1, and
+# an `issue close` invocation is captured to $FAKE_ISSUE_CLOSE_ARGS. Everything
+# else exits 0 with no output.
+fake_merge_gh() {
+  local state="${1:-OPEN}"
+  fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"view\" ]]; then
+  printf \"$state\n\"
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"close\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_ISSUE_CLOSE_ARGS:-/dev/null}\"
+fi
+exit 0"
+}
+
+# Fake git that removes the dir on `worktree remove`, mirroring how the
+# cleanup helper is invoked by the orchestrator.
+fake_merge_git() {
+  fake_command git 'if [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+  rm -rf "$3" "$4"
+elif [[ "$1" == "branch" && "$2" == "-D" ]]; then
+  exit 0
+fi
+exit 0'
+}
+
 STATE_DIR=""
 TEST_STATE=""
 WT_PARENT=""
@@ -1232,6 +1256,160 @@ test_poll_once_runs_review_loop() {
   state_teardown
 }
 
+test_pr_state_returns_merged() {
+  fake_merge_gh "MERGED"
+  assert_eq "pr state returns MERGED" "MERGED" "$(orchestrator_pr_state 456)"
+}
+
+test_pr_state_returns_closed() {
+  fake_merge_gh "CLOSED"
+  assert_eq "pr state returns CLOSED" "CLOSED" "$(orchestrator_pr_state 456)"
+}
+
+test_pr_state_returns_open() {
+  fake_merge_gh "OPEN"
+  assert_eq "pr state returns OPEN" "OPEN" "$(orchestrator_pr_state 456)"
+}
+
+test_pr_state_gh_error() {
+  fake_command gh 'exit 1'
+  assert_eq "pr state empty on gh error" "" "$(orchestrator_pr_state 456)"
+}
+
+test_merge_poll_prunes_merged_pr() {
+  state_setup
+  fake_merge_gh "MERGED"
+  fake_merge_git
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_ISSUE_CLOSE_ARGS="$STATE_DIR/issue_close"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "merged pr removed from state" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "merged pr worktree removed" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "merged pr closes issue with comment" "PR #456 merged. Issue closed." "$(cat "$FAKE_ISSUE_CLOSE_ARGS")"
+  assert_contains "logs merge detected" "PR #456 merged" "$output"
+  unset FAKE_ISSUE_CLOSE_ARGS
+  state_teardown
+}
+
+test_merge_poll_prunes_closed_pr() {
+  state_setup
+  fake_merge_gh "CLOSED"
+  fake_merge_git
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_ISSUE_CLOSE_ARGS="$STATE_DIR/issue_close"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>/dev/null
+  assert_eq "closed without merge removed from state" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "closed without merge worktree removed" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "closed without merge does not close issue" "no" "$([[ -f "$FAKE_ISSUE_CLOSE_ARGS" ]] && echo yes || echo no)"
+  unset FAKE_ISSUE_CLOSE_ARGS
+  state_teardown
+}
+
+test_merge_poll_keeps_entry_when_close_fails() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf "MERGED\n"
+elif [[ "$1" == "issue" && "$2" == "close" ]]; then
+  exit 1
+fi
+exit 0'
+  fake_merge_git
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "failed issue close keeps entry in state" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "failed issue close keeps worktree" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "logs close retry warning" "keeping entry to retry next poll" "$output"
+  state_teardown
+}
+
+test_merge_poll_keeps_open_pr() {
+  state_setup
+  fake_merge_gh "OPEN"
+  fake_command git 'exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>/dev/null
+  assert_eq "open pr kept in state" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "open pr worktree kept" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  state_teardown
+}
+
+test_merge_poll_skips_entry_without_pr() {
+  state_setup
+  fake_command gh 'exit 0'
+  fake_command git 'exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc ""
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "entry without pr stays in state" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "logs skip for missing pr" "no PR recorded" "$output"
+  state_teardown
+}
+
+test_merge_poll_gh_error_keeps_entry() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  exit 1
+fi
+exit 0'
+  fake_command git 'exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "gh error keeps entry in state" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "logs gh error handling" "could not determine state" "$output"
+  state_teardown
+}
+
+test_merge_poll_ignores_implementing_phase() {
+  state_setup
+  fake_merge_gh "MERGED"
+  fake_command git 'exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>/dev/null
+  assert_eq "implementing entry untouched" "1" "$(jq 'length' "$TEST_STATE")"
+  state_teardown
+}
+
+test_poll_once_runs_merge_poll() {
+  state_setup
+  fake_merge_gh "MERGED"
+  fake_merge_git
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_ISSUE_CLOSE_ARGS="$STATE_DIR/issue_close"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_poll_once 2>&1)"
+  assert_eq "poll once prunes merged pr" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "poll once closes issue on merge" "PR #456 merged. Issue closed." "$(cat "$FAKE_ISSUE_CLOSE_ARGS")"
+  assert_contains "logs merge poll" "PR #456 merged" "$output"
+  unset FAKE_ISSUE_CLOSE_ARGS
+  state_teardown
+}
+
 test_state_add_creates_review_notice_false() {
   state_setup
   orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$WT_PARENT/123-foo"
@@ -1412,6 +1590,18 @@ test_review_poll_ignores_implementing_phase
 test_review_poll_retries_failed_round
 test_review_poll_pauses_after_three_failures
 test_review_poll_resumes_after_pause_on_new_comment
+test_pr_state_returns_merged
+test_pr_state_returns_closed
+test_pr_state_returns_open
+test_pr_state_gh_error
+test_merge_poll_prunes_merged_pr
+test_merge_poll_prunes_closed_pr
+test_merge_poll_keeps_entry_when_close_fails
+test_merge_poll_keeps_open_pr
+test_merge_poll_skips_entry_without_pr
+test_merge_poll_gh_error_keeps_entry
+test_merge_poll_ignores_implementing_phase
+test_poll_once_runs_merge_poll
 test_implement_runs_full_pipeline
 test_implement_fails_when_worktree_fails
 test_implement_fails_when_npm_ci_fails

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -168,6 +168,18 @@ fi
 exit 0'
 }
 
+# Fake gh for a closed-without-merge PR: `pr view` reports CLOSED, and the
+# escalation `issue edit` + `issue comment` invocations are captured to
+# $FAKE_ESCALATE_ARGS (appended).
+fake_closed_escalate_gh() {
+  fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"view\" ]]; then
+  printf \"CLOSED\n\"
+elif [[ \"\$1\" == \"issue\" && ( \"\$2\" == \"edit\" || \"\$2\" == \"comment\" ) ]]; then
+  printf \"%s\n\" \"\$*\" >> \"\${FAKE_ESCALATE_ARGS:-/dev/null}\"
+fi
+exit 0"
+}
+
 STATE_DIR=""
 TEST_STATE=""
 WT_PARENT=""
@@ -1297,18 +1309,41 @@ test_merge_poll_prunes_merged_pr() {
 
 test_merge_poll_prunes_closed_pr() {
   state_setup
-  fake_merge_gh "CLOSED"
+  fake_closed_escalate_gh
   fake_merge_git
   local worktree="$WT_PARENT/123-foo"
   mkdir -p "$worktree"
-  export FAKE_ISSUE_CLOSE_ARGS="$STATE_DIR/issue_close"
+  export FAKE_ESCALATE_ARGS="$STATE_DIR/escalate"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>/dev/null
   assert_eq "closed without merge removed from state" "0" "$(jq 'length' "$TEST_STATE")"
   assert_eq "closed without merge worktree removed" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
-  assert_eq "closed without merge does not close issue" "no" "$([[ -f "$FAKE_ISSUE_CLOSE_ARGS" ]] && echo yes || echo no)"
-  unset FAKE_ISSUE_CLOSE_ARGS
+  assert_contains "closed without merge drops in-progress label" "--remove-label in-progress" "$(cat "$FAKE_ESCALATE_ARGS")"
+  assert_contains "closed without merge adds needs-triage label" "--add-label needs-triage" "$(cat "$FAKE_ESCALATE_ARGS")"
+  assert_contains "closed without merge comments naming the pr" "PR #456 was closed without merging" "$(cat "$FAKE_ESCALATE_ARGS")"
+  unset FAKE_ESCALATE_ARGS
+  state_teardown
+}
+
+test_merge_poll_keeps_entry_when_escalate_fails() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf "CLOSED\n"
+elif [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  exit 1
+fi
+exit 0'
+  fake_merge_git
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "failed escalation keeps entry in state" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "failed escalation keeps worktree" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "logs escalation retry warning" "keeping entry to retry next poll" "$output"
   state_teardown
 }
 
@@ -1596,6 +1631,7 @@ test_pr_state_returns_open
 test_pr_state_gh_error
 test_merge_poll_prunes_merged_pr
 test_merge_poll_prunes_closed_pr
+test_merge_poll_keeps_entry_when_escalate_fails
 test_merge_poll_keeps_entry_when_close_fails
 test_merge_poll_keeps_open_pr
 test_merge_poll_skips_entry_without_pr

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -144,13 +144,16 @@ fi
 exit 1"
 }
 
-# Fake gh for the merge poll: `pr view` returns the PR state passed as $1, and
-# an `issue close` invocation is captured to $FAKE_ISSUE_CLOSE_ARGS. Everything
+# Fake gh for the merge poll: `pr view` returns the PR state passed as $1, an
+# `issue edit` (label removal) is captured to $FAKE_ISSUE_EDIT_ARGS, and an
+# `issue close` invocation is captured to $FAKE_ISSUE_CLOSE_ARGS. Everything
 # else exits 0 with no output.
 fake_merge_gh() {
   local state="${1:-OPEN}"
   fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"view\" ]]; then
   printf \"$state\n\"
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"edit\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_ISSUE_EDIT_ARGS:-/dev/null}\"
 elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"close\" ]]; then
   printf \"%s\n\" \"\$*\" > \"\${FAKE_ISSUE_CLOSE_ARGS:-/dev/null}\"
 fi
@@ -1295,15 +1298,17 @@ test_merge_poll_prunes_merged_pr() {
   local worktree="$WT_PARENT/123-foo"
   mkdir -p "$worktree"
   export FAKE_ISSUE_CLOSE_ARGS="$STATE_DIR/issue_close"
+  export FAKE_ISSUE_EDIT_ARGS="$STATE_DIR/issue_edit"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
   local output
   output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
   assert_eq "merged pr removed from state" "0" "$(jq 'length' "$TEST_STATE")"
   assert_eq "merged pr worktree removed" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "merged pr removes in-progress label" "--remove-label in-progress" "$(cat "$FAKE_ISSUE_EDIT_ARGS")"
   assert_contains "merged pr closes issue with comment" "PR #456 merged. Issue closed." "$(cat "$FAKE_ISSUE_CLOSE_ARGS")"
   assert_contains "logs merge detected" "PR #456 merged" "$output"
-  unset FAKE_ISSUE_CLOSE_ARGS
+  unset FAKE_ISSUE_CLOSE_ARGS FAKE_ISSUE_EDIT_ARGS
   state_teardown
 }
 


### PR DESCRIPTION
## Summary

Adds the merge-detection poll to the orchestrator, completing the ticket→PR→merged→closed lifecycle.

- `orchestrator_pr_state` — queries `gh pr view --json state` for an awaiting-review PR.
- `orchestrator_merge_poll` — walks awaiting-review entries each cycle (before the review loop):
  - **MERGED**: drops `in-progress`, closes the issue with `PR #<N> merged. Issue closed.`, prunes worktree/branch, removes the state entry. Keeps the entry (retrying) if the close fails.
  - **CLOSED** (without merge): prunes worktree/branch, then escalates the issue — drops `in-progress`, adds `needs-triage`, comments naming the closed PR. Removes the entry only once the escalation lands.
  - **OPEN**: untouched.
- Extracts `orchestrator_awaiting_review_entries` and `orchestrator_prune_ticket` shared by the merge and review polls.

Closes #220

## Testing

- `npm run test:tools` — 184 tests pass (incl. new merge/close/escalation/retry cases).
- `npm run prettier:check` — clean.

## Notes

- Concurrency-slot semantics and parallel sessions are tracked separately in #239 (needs a grilling session).
- Startup crash recovery remains #221, now unblocked by this PR.

---
_Created by carbotracker's agent skills._