### PR TITLE
Implement #221 — Crash recovery and robustness

### DIFF
--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -149,12 +149,15 @@ orchestrator_opencode_session_id() {
   local title="$1"
   opencode session list --format json 2>/dev/null \
     | jq -r --arg t "$title" \
-        '[.[] | select(.title == $t)] | sort_by(.created) | reverse | .[0].id // empty'
+        '[.[] | select(.title == $t)] | sort_by(.created) | reverse | .[0].id // empty' 2>/dev/null || true
 }
 
 orchestrator_pr_number_for_branch() {
   local branch="$1"
-  gh pr list --head "$branch" --json number 2>/dev/null \
+  # --state all so a merged or closed PR for the branch still counts: during
+  # crash recovery the orchestrator must never open a duplicate PR for a
+  # branch that already has one in any state.
+  gh pr list --head "$branch" --state all --json number 2>/dev/null \
     | jq -r 'sort_by(.number) | reverse | .[0].number // empty' 2>/dev/null || true
 }
 
@@ -342,6 +345,19 @@ _Created by carbotracker's agent skills._"; then
   done < <(orchestrator_awaiting_review_entries)
 }
 
+orchestrator_create_pr() {
+  local number="$1" title="$2" branch="$3"
+  orchestrator_log "creating PR for #$number ($title)"
+  if ! gh pr create --base main --head "$branch" --title "Implement $title (#$number)" \
+      --body "Automated implementation of #$number.
+
+---
+_Created by carbotracker's agent skills._" >&2; then
+    orchestrator_log "ERROR: gh pr create failed for #$number"
+    return 1
+  fi
+}
+
 orchestrator_push_and_open_pr() {
   local number="$1" title="$2" branch="$3" worktree="$4"
   local pr_number
@@ -354,13 +370,7 @@ orchestrator_push_and_open_pr() {
   fi
   pr_number="$(orchestrator_pr_number_for_branch "$branch")"
   if [[ -z "$pr_number" ]]; then
-    orchestrator_log "creating PR for #$number ($title)"
-    if ! gh pr create --base main --head "$branch" --title "Implement $title (#$number)" \
-        --body "Automated implementation of #$number.
-
----
-_Created by carbotracker's agent skills._" >&2; then
-      orchestrator_log "ERROR: gh pr create failed for #$number"
+    if ! orchestrator_create_pr "$number" "$title" "$branch"; then
       return 1
     fi
     pr_number="$(orchestrator_pr_number_for_branch "$branch")"
@@ -374,9 +384,72 @@ orchestrator_cleanup_worktree() {
   git branch -D "$branch" 2>/dev/null || true
 }
 
+orchestrator_run_opencode() {
+  local worktree="$1" number="$2" log_file="$3"
+  shift 3
+  local prompt="/implement the issue is $number"
+  if (cd "$worktree" && opencode run --auto "$@" "$prompt") 2>&1 | tee "$log_file"; then
+    return 0
+  fi
+  orchestrator_log "ERROR: opencode run failed for #$number (attempt 1); retrying with --continue"
+  if (cd "$worktree" && opencode run --auto --continue "$prompt") 2>&1 | tee -a "$log_file"; then
+    return 0
+  fi
+  orchestrator_log "ERROR: opencode run failed for #$number on the retry as well"
+  return 1
+}
+
+orchestrator_escalate_failure() {
+  local number="$1" branch="$2" worktree="$3" log_file="$4" reason="$5"
+  local tail snippet body
+  tail="$(tail -n 30 "$log_file" 2>/dev/null || true)"
+  snippet=""
+  if [[ -n "$tail" ]]; then
+    snippet="$(printf '\n```\n%s\n```' "$tail")"
+  fi
+  body="Automated implementation of #$number failed: $reason. Escalated to needs-triage for human review.
+${snippet}
+---
+_Created by carbotracker's agent skills._"
+  if gh issue edit "$number" --remove-label "$ORCHESTRATOR_IN_PROGRESS_LABEL" --remove-label ticket --add-label needs-triage \
+    && gh issue comment "$number" --body "$body"; then
+    orchestrator_prune_ticket "$number" "$branch" "$worktree"
+    orchestrator_log "escalated #$number to needs-triage after $reason; pruned worktree and removed from state"
+    return 0
+  fi
+  orchestrator_log "WARNING: failed to escalate #$number; leaving entry in state for the poll loop to un-claim"
+  return 1
+}
+
+orchestrator_state_complete_and_comment() {
+  local number="$1" session_id="$2" pr_number="$3"
+  orchestrator_state_complete "$ORCHESTRATOR_STATE_FILE" "$number" "$session_id" "$pr_number"
+  orchestrator_log "completed #$number: session ${session_id:-<none>}, PR #${pr_number:-<none>}, phase awaiting review"
+  if [[ -n "$pr_number" ]]; then
+    if gh issue comment "$number" --body "Started implementation. PR #$pr_number created."; then
+      orchestrator_log "commented on #$number: Started implementation. PR #$pr_number created."
+    else
+      orchestrator_log "WARNING: failed to comment on #$number"
+    fi
+  else
+    orchestrator_log "WARNING: no PR found for #$number; skipping issue comment"
+  fi
+}
+
+orchestrator_finish_implementation() {
+  local number="$1" title="$2" branch="$3" worktree="$4" session_title="$5"
+  local session_id pr_number
+  session_id="$(orchestrator_opencode_session_id "$session_title")"
+  if ! pr_number="$(orchestrator_push_and_open_pr "$number" "$title" "$branch" "$worktree")"; then
+    orchestrator_log "ERROR: push or PR creation failed for #$number"
+    return 1
+  fi
+  orchestrator_state_complete_and_comment "$number" "$session_id" "$pr_number"
+}
+
 orchestrator_implement() {
   local number="$1" title="$2" branch="$3" worktree="$4"
-  local session_title session_id pr_number
+  local session_title session_id pr_number log_file
 
   orchestrator_log "implementing #$number: creating worktree $worktree (branch $branch)"
   if ! ct_worktree_add "$worktree" "$branch"; then
@@ -391,29 +464,157 @@ orchestrator_implement() {
   fi
 
   session_title="carbotracker-ticket-$number"
+  log_file="$(mktemp "${TMPDIR:-/tmp}/carbotracker-opencode.XXXXXX")"
   orchestrator_log "launching opencode for #$number (title $session_title)"
-  if ! (cd "$worktree" && opencode run --auto --title "$session_title" "/implement the issue is $number"); then
-    orchestrator_log "ERROR: opencode run failed for #$number"
+  if ! orchestrator_run_opencode "$worktree" "$number" "$log_file" --title "$session_title"; then
+    orchestrator_escalate_failure "$number" "$branch" "$worktree" "$log_file" "opencode exited non-zero twice"
+    rm -f "$log_file"
     return 1
   fi
+  rm -f "$log_file"
 
-  session_id="$(orchestrator_opencode_session_id "$session_title")"
-  if ! pr_number="$(orchestrator_push_and_open_pr "$number" "$title" "$branch" "$worktree")"; then
-    orchestrator_log "ERROR: push or PR creation failed for #$number"
+  orchestrator_finish_implementation "$number" "$title" "$branch" "$worktree" "$session_title"
+}
+
+# ---- Crash recovery ----
+
+orchestrator_branch_pushed() {
+  local branch="$1"
+  git ls-remote origin "refs/heads/$branch" 2>/dev/null | grep -q .
+}
+
+orchestrator_unpushed_commit_count() {
+  local worktree="$1" branch="$2"
+  local base="origin/main"
+  if git -C "$worktree" rev-parse --verify -q "refs/remotes/origin/$branch" >/dev/null 2>&1; then
+    base="refs/remotes/origin/$branch"
+  fi
+  git -C "$worktree" rev-list --count "$base..HEAD" 2>/dev/null || echo 0
+}
+
+orchestrator_worktree_has_work() {
+  local worktree="$1" branch="$2"
+  if [[ ! -d "$worktree" ]]; then
     return 1
   fi
-  orchestrator_state_complete "$ORCHESTRATOR_STATE_FILE" "$number" "$session_id" "$pr_number"
+  if ! git -C "$worktree" rev-parse --git-dir >/dev/null 2>&1; then
+    return 1
+  fi
+  if [[ -n "$(git -C "$worktree" status --porcelain 2>/dev/null)" ]]; then
+    return 0
+  fi
+  if [[ "$(orchestrator_unpushed_commit_count "$worktree" "$branch")" -gt 0 ]]; then
+    return 0
+  fi
+  return 1
+}
 
-  orchestrator_log "completed #$number: session ${session_id:-<none>}, PR #${pr_number:-<none>}, phase awaiting review"
-  if [[ -n "$pr_number" ]]; then
-    if gh issue comment "$number" --body "Started implementation. PR #$pr_number created."; then
-      orchestrator_log "commented on #$number: Started implementation. PR #$pr_number created."
-    else
-      orchestrator_log "WARNING: failed to comment on #$number"
-    fi
+orchestrator_resume_implementation() {
+  local number="$1" title="$2" branch="$3" worktree="$4" session_id="$5"
+  local session_title log_file run_flags
+  session_title="carbotracker-ticket-$number"
+  orchestrator_log "resuming implementation #$number in $worktree"
+
+  if [[ -n "$session_id" ]]; then
+    run_flags=(--session "$session_id")
   else
-    orchestrator_log "WARNING: no PR found for branch $branch on #$number; skipping issue comment"
+    run_flags=(--continue)
   fi
+  log_file="$(mktemp "${TMPDIR:-/tmp}/carbotracker-opencode.XXXXXX")"
+  if ! orchestrator_run_opencode "$worktree" "$number" "$log_file" "${run_flags[@]}"; then
+    orchestrator_escalate_failure "$number" "$branch" "$worktree" "$log_file" "opencode exited non-zero twice while resuming"
+    rm -f "$log_file"
+    return 1
+  fi
+  rm -f "$log_file"
+
+  orchestrator_finish_implementation "$number" "$title" "$branch" "$worktree" "$session_title"
+}
+
+orchestrator_recover_pushed_branch() {
+  local number="$1" title="$2" branch="$3" worktree="$4" session_id="$5"
+  local pr_number
+  if [[ -z "$session_id" ]]; then
+    session_id="$(orchestrator_opencode_session_id "carbotracker-ticket-$number")"
+  fi
+  pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  if [[ -z "$pr_number" ]]; then
+    if ! orchestrator_create_pr "$number" "$title" "$branch"; then
+      return 1
+    fi
+    pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+  fi
+  orchestrator_state_complete_and_comment "$number" "$session_id" "$pr_number"
+}
+
+orchestrator_drop_unrecoverable() {
+  local number="$1" branch="$2" worktree="$3"
+  orchestrator_cleanup_worktree "$worktree" "$branch"
+  if ! gh issue comment "$number" --body "The orchestrator found no recoverable work for this ticket after a restart. It has been cleaned up and removed from the pipeline. Re-tag with ready-for-agent to retry.
+---
+_Created by carbotracker's agent skills._"; then
+    orchestrator_log "WARNING: failed to comment on #$number; keeping entry to retry on the next restart"
+    return 1
+  fi
+  # Un-claim on GitHub: drop in-progress so the issue is no longer marked as
+  # being worked, but do not re-add ready-for-agent — the comment above is the
+  # handoff to a human, and an automatic re-claim could loop on a broken ticket.
+  gh issue edit "$number" --remove-label "$ORCHESTRATOR_IN_PROGRESS_LABEL" 2>/dev/null \
+    || orchestrator_log "WARNING: failed to remove $ORCHESTRATOR_IN_PROGRESS_LABEL from #$number"
+  orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+  orchestrator_log "recovered #$number: nothing recoverable; cleaned up, removed from state"
+}
+
+orchestrator_reconcile() {
+  local line number title branch worktree session_id pr_number
+  orchestrator_log "reconciling state file against observable git facts"
+  while IFS= read -r line; do
+    number="$(printf '%s' "$line" | jq -r '.ticket')"
+    branch="$(printf '%s' "$line" | jq -r '.branch')"
+    worktree="$(printf '%s' "$line" | jq -r '.worktree')"
+    session_id="$(printf '%s' "$line" | jq -r '.sessionId // ""')"
+    if [[ "$session_id" == "null" ]]; then
+      session_id=""
+    fi
+    title="$(gh issue view "$number" --json title --jq .title 2>/dev/null || true)"
+    if [[ -z "$title" ]]; then
+      # gh is transiently down (or the issue is gone): do not destroy state —
+      # leave the entry untouched so the next restart re-inspects it.
+      orchestrator_log "WARNING: could not resolve issue #$number; skipping entry until the next restart"
+      continue
+    fi
+
+    pr_number="$(orchestrator_pr_number_for_branch "$branch")"
+    if [[ -n "$pr_number" ]]; then
+      if [[ -z "$session_id" ]]; then
+        session_id="$(orchestrator_opencode_session_id "carbotracker-ticket-$number")"
+      fi
+      orchestrator_log "recovered #$number: PR #$pr_number exists for branch $branch; setting phase awaiting review"
+      orchestrator_state_complete "$ORCHESTRATOR_STATE_FILE" "$number" "$session_id" "$pr_number"
+      continue
+    fi
+
+    if orchestrator_branch_pushed "$branch"; then
+      orchestrator_log "recovered #$number: branch $branch pushed but no PR; creating the PR"
+      if orchestrator_recover_pushed_branch "$number" "$title" "$branch" "$worktree" "$session_id"; then
+        orchestrator_log "recovered #$number: PR created for pushed branch $branch"
+      else
+        orchestrator_log "ERROR: could not create a PR for recovered #$number"
+      fi
+      continue
+    fi
+
+    if orchestrator_worktree_has_work "$worktree" "$branch"; then
+      orchestrator_log "recovered #$number: worktree has unpushed work; resuming implementation"
+      if ! orchestrator_resume_implementation "$number" "$title" "$branch" "$worktree" "$session_id"; then
+        orchestrator_log "ERROR: could not resume implementation for #$number"
+      fi
+      continue
+    fi
+
+    orchestrator_log "recovered #$number: nothing recoverable; cleaning up"
+    orchestrator_drop_unrecoverable "$number" "$branch" "$worktree"
+  done < <(orchestrator_state_load "$ORCHESTRATOR_STATE_FILE" | jq -c '.[]')
 }
 
 orchestrator_poll_once() {
@@ -454,12 +655,19 @@ orchestrator_poll_once() {
     active_count=$((active_count + 1))
 
     if ! orchestrator_implement "$number" "$title" "$branch" "$worktree"; then
-      orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
-      orchestrator_log "removed #$number from state after failed implementation"
-      if [[ "${CT_WORKTREE_CREATED:-0}" == "1" ]]; then
-        orchestrator_cleanup_worktree "$worktree" "$branch"
+      if orchestrator_state_has_ticket "$ORCHESTRATOR_STATE_FILE" "$number"; then
+        # Non-opencode failure (worktree/npm/push/PR): un-claim and clean up,
+        # the next poll starts the ticket over. When opencode failed twice the
+        # implementation already escalated and pruned, so the entry is gone.
+        orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+        orchestrator_log "removed #$number from state after failed implementation"
+        if [[ "${CT_WORKTREE_CREATED:-0}" == "1" ]]; then
+          orchestrator_cleanup_worktree "$worktree" "$branch"
+        else
+          orchestrator_log "not cleaning up pre-existing worktree $worktree"
+        fi
       else
-        orchestrator_log "not cleaning up pre-existing worktree $worktree"
+        orchestrator_log "#$number already escalated and pruned after failed implementation"
       fi
       active_count=$((active_count - 1))
     fi
@@ -471,6 +679,7 @@ orchestrator_poll_once() {
 
 orchestrator_daemon() {
   orchestrator_log "orchestrator started: poll every ${ORCHESTRATOR_POLL_INTERVAL_SECONDS}s, concurrency cap $ORCHESTRATOR_CONCURRENCY_CAP, state $ORCHESTRATOR_STATE_FILE"
+  orchestrator_reconcile
   while true; do
     orchestrator_poll_once
     orchestrator_log "sleeping ${ORCHESTRATOR_POLL_INTERVAL_SECONDS}s until the next poll"
@@ -492,6 +701,7 @@ main() {
   fi
   case "${1:-}" in
     once | --once)
+      orchestrator_reconcile
       orchestrator_poll_once
       ;;
     help | --help | -h)

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -10,6 +10,12 @@ for new comments and, when it finds one, resumes the original opencode session
 with `/review-comments` so the agent answers the review and pushes updates. It
 runs as a systemd user service (see `carbotracker-orchestrator.service`).
 
+On startup the daemon first **reconciles** the state file against observable
+git facts (see [Crash recovery](#crash-recovery)), so a VPS restart or crashed
+run resumes from what actually exists on disk rather than from stale in-memory
+state. A failing `opencode run` is retried once with `--continue` before the
+ticket is escalated to a human (see [opencode failures](#opencode-failures)).
+
 ## Lifecycle
 
 A ticket moves through phases as the orchestrator works it:
@@ -19,10 +25,15 @@ stateDiagram-v2
     [*] --> implementing: poll finds eligible ticket, claim flips GitHub labels
     implementing --> awaiting_review: opencode done, PR opened
     implementing --> [*]: failure, un-claim and clean up
+    implementing --> [*]: opencode fails twice, escalated to needs-triage
     awaiting_review --> review_round: new comment on PR (newer than lastCommentAt)
     review_round --> awaiting_review: /review-comments succeeds or a retry fails
     awaiting_review --> [*]: merge poll sees PR merged, closes issue
     awaiting_review --> [*]: merge poll sees PR closed without merge
+    [*] --> recovering: daemon startup reconcile
+    recovering --> implementing: worktree has unpushed work, resume opencode
+    recovering --> awaiting_review: PR exists or branch pushed, create/keep PR
+    recovering --> [*]: nothing recoverable, clean up and return to queue
 ```
 
 `implementing` means the orchestrator is actively running a session for the
@@ -57,6 +68,56 @@ Each poll, before the review loop, the orchestrator walks every state entry in
 - **`OPEN`** — still awaiting review, nothing to do.
 - **anything else / gh failure** — the state query failed; the entry is kept
   so the merge is retried on the next poll.
+
+## Crash recovery
+
+The state file is the orchestrator's memory, never the source of truth. On
+daemon startup (`once` mode too) the orchestrator runs `orchestrator_reconcile`,
+which walks every entry in the state file and inspects the observable facts —
+does the worktree directory exist, what does `git status`/`git log` say, is the
+branch pushed (`git ls-remote`), and is there a PR for the branch (`gh pr list
+--head <branch> --state all`). It then transitions each ticket to the phase
+that matches reality:
+
+- **PR exists** — the implementation finished; set phase `awaiting review`,
+  record the PR number, and let the merge/review polls pick the entry up from
+  the next poll.
+- **Branch pushed, no PR** — the crash happened between push and PR creation.
+  The orchestrator creates the PR (`gh pr create`), transitions to
+  `awaiting review`, and comments "Started implementation. PR #&lt;n&gt;
+  created." Duplicate PRs are impossible: `pr list --state all` also matches a
+  merged or closed PR, so a branch that already has one is never re-created.
+- **Worktree has unpushed work** (local changes or commits not on the remote
+  branch) — the crash interrupted an implementation. Dependencies were already
+  installed before the agent started, so the orchestrator resumes the run
+  directly: `opencode run --auto --continue` (or `--session <id>` when the
+  state file already records one) with `/implement`, then push, PR, and
+  `awaiting review`. The same opencode retry/escalation rules apply as for a
+  fresh run.
+- **Nothing recoverable** (clean worktree, branch never pushed, no PR, or the
+  worktree is gone) — the crash happened before any work landed. The
+  orchestrator prunes the worktree and branch, comments on the issue that no
+  recoverable work was found, drops `in-progress`, and removes the entry from
+  state. The comment is the handoff to a human: `ready-for-agent` is **not**
+  re-added automatically, so a broken ticket does not loop through the
+  pipeline — re-tag it to retry.
+
+Each entry is handled independently; a failure on one (e.g. `gh` transiently
+down) logs a warning and leaves the entry for the next restart rather than
+blocking the rest.
+
+## opencode failures
+
+A fresh or resumed implementation runs `opencode run --auto` (with `--title`,
+`--session`, or `--continue` depending on the situation). On a non-zero exit it
+is **retried once** with `opencode run --auto --continue` against the same
+session. If the retry also fails, the orchestrator **escalates**: it removes
+`in-progress` and `ticket` (the `ready-for-agent` label was already removed at
+claim time), adds `needs-triage`, comments on the issue with the failure reason
+and the tail of the run's output, prunes the worktree and branch, and removes
+the entry from state. The ticket is now a human problem, not a pipeline
+retry-loop. If the escalation itself fails, the entry stays in state and the
+poll loop's normal un-claim/cleanup path removes it.
 
 ## Review loop
 
@@ -127,16 +188,33 @@ Active tickets live in a single JSON array, written atomically
 | `phase`              | `implementing` or `awaiting review`                               |
 | `startedAt`          | UTC timestamp of the claim                                        |
 
-## Data flow per poll
+## Data flow
+
+The full flow: startup reconciliation, then each poll cycle.
 
 ```mermaid
 flowchart TD
-    A[gh issue list ready-for-agent,ticket] --> B{unblocked? skip already-claimed / blocked / at cap}
+    S[startup: reconcile state entries against git facts] --> S1{PR exists for branch?}
+    S1 -- yes --> AR[phase awaiting review, begin polling]
+    S1 -- no --> S2{branch pushed?}
+    S2 -- yes --> S3[create PR + phase awaiting review]
+    S2 -- no --> S4{worktree has unpushed work?}
+    S4 -- yes --> S5[resume opencode --continue, then push + PR]
+    S4 -- no --> S6[prune worktree, comment, drop in-progress, remove from state]
+    S5 --> AR
+    S3 --> AR
+    AR --> A[gh issue list ready-for-agent,ticket] --> B{unblocked? skip already-claimed / blocked / at cap}
     B -- eligible --> C[claim: remove ready-for-agent, add in-progress + append state entry]
     C --> D[ct_worktree_add: git fetch origin/main + worktree add -b ticket/N-slug]
     D --> E[npm ci --prefer-offline --no-audit --no-fund]
     E --> F[opencode run --auto --title carbotracker-ticket-N /implement the issue is N]
-    F --> G[opencode session list → sessionId by title]
+    F --> F1{non-zero exit?}
+    F1 -- no --> G
+    F1 -- yes --> F2[retry: opencode run --auto --continue /implement the issue is N]
+    F2 --> F3{non-zero again?}
+    F3 -- no --> G
+    F3 -- yes --> F4[escalate: needs-triage, comment with output, prune, remove from state]
+    G[opencode session list → sessionId by title]
     G --> H[git push -u origin branch]
     H --> I{PR exists?}
     I -- no --> J[gh pr create --base main --head branch]
@@ -201,7 +279,17 @@ Follow the daemon with `journalctl --user -u carbotracker-orchestrator -f`.
   `opencode` run, which is wasteful but simple and safe. Cleanup is guarded:
   only a worktree this run actually created (`CT_WORKTREE_CREATED`) is
   removed, so a parallel orchestrator that loses the claim race never deletes
-  the winner's worktree.
+  the winner's worktree. When `opencode` itself fails, the failure is not
+  retried by re-claiming: the run is retried once in place with `--continue`,
+  then the ticket is escalated to `needs-triage` so a broken ticket stops
+  consuming pipeline effort (see [opencode failures](#opencode-failures)).
+- Recovery never trusts the state file's phase: `orchestrator_reconcile`
+  derives the phase from `git status`, `git log`, `git ls-remote`, and
+  `gh pr list --state all`. `prNumber` from the state file is ignored in
+  favour of
+  what the remote actually reports, so a crash between push and PR creation is
+  recovered by creating the PR rather than re-running the agent, and a branch
+  whose PR was already merged is never given a second PR.
 - Review detection compares strictly against the watermark. The watermark is
   the newest comment that is **not** the pipeline's own output — comments and
   reviews carrying the `_Created by carbotracker's agent skills._` footer are

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -183,6 +183,75 @@ fi
 exit 0"
 }
 
+# Fake git that answers the git-fact queries the reconcile step makes.
+# count: commits the worktree reports ahead of the base; dirty: whether
+# `status --porcelain` is non-empty; pushed: whether `ls-remote` reports
+# the branch on origin.
+fake_reconcile_git() {
+  local count="${1:-0}" dirty="${2:-no}" pushed="${3:-no}"
+  fake_command git "if [[ \"\$1\" == \"-C\" ]]; then
+  shift 2
+  if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+  elif [[ \"\$1\" == \"status\" ]]; then
+    if [[ \"$dirty\" == \"yes\" ]]; then printf \" M file.txt\n\"; fi
+    exit 0
+  elif [[ \"\$1\" == \"rev-list\" ]]; then
+    printf \"$count\n\"
+    exit 0
+  elif [[ \"\$1\" == \"push\" ]]; then
+    exit 0
+  fi
+elif [[ \"\$1\" == \"ls-remote\" ]]; then
+  if [[ \"$pushed\" == \"yes\" ]]; then printf \"abc1234\trefs/heads/\${3##*/}\n\"; fi
+  exit 0
+elif [[ \"\$1\" == \"worktree\" ]]; then
+  if [[ \"\$2\" == \"remove\" ]]; then rm -rf \"\$3\" \"\$4\"; fi
+  exit 0
+elif [[ \"\$1\" == \"branch\" || \"\$1\" == \"fetch\" ]]; then
+  exit 0
+fi
+exit 0"
+}
+
+# Fake gh that answers the reconcile-step queries: `pr list` returns the
+# given PR number when non-empty (otherwise an empty list), `pr create` is
+# captured, and `issue view` / `issue comment` / `issue edit` are captured.
+fake_reconcile_gh() {
+  local pr_number="${1:-}"
+  fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"list\" ]]; then
+  if [[ -n \"$pr_number\" ]]; then printf \"[{\\\"number\\\":$pr_number}]\n\"; else printf \"[]\n\"; fi
+  exit 0
+elif [[ \"\$1\" == \"pr\" && \"\$2\" == \"create\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_PR_CREATE_ARGS:-/dev/null}\"
+  exit 0
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"view\" ]]; then
+  printf \"Some Title\n\"
+  exit 0
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"comment\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_ISSUE_COMMENT_ARGS:-/dev/null}\"
+  exit 0
+elif [[ \"\$1\" == \"issue\" && \"\$2\" == \"edit\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_ISSUE_EDIT_ARGS:-/dev/null}\"
+  exit 0
+fi
+exit 0"
+}
+
+# Fake opencode run that exits 0 and captures the invocation; `session list`
+# returns the given session id (or none).
+fake_reconcile_opencode() {
+  local session_id="${1:-}"
+  fake_command opencode "if [[ \"\$1\" == \"run\" ]]; then
+  printf \"%s\n\" \"\$*\" > \"\${FAKE_OPENCODE_ARGS:-/dev/null}\"
+  exit 0
+elif [[ \"\$1\" == \"session\" ]]; then
+  if [[ -n \"$session_id\" ]]; then printf \"[{\\\"id\\\":\\\"$session_id\\\",\\\"title\\\":\\\"carbotracker-ticket-123\\\",\\\"created\\\":1}]\n\"; else printf \"[]\n\"; fi
+  exit 0
+fi
+exit 0"
+}
+
 STATE_DIR=""
 TEST_STATE=""
 WT_PARENT=""
@@ -731,21 +800,74 @@ exit 0'
   state_teardown
 }
 
-test_implement_fails_when_opencode_fails() {
+test_implement_retries_opencode_with_continue() {
   state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[{\"number\":42}]\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_worktree_npm
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  local n
+  n="$(cat "$FAKE_OPENCODE_COUNT" 2>/dev/null || echo 0)"
+  n=$((n + 1))
+  printf "%d\n" "$n" > "$FAKE_OPENCODE_COUNT"
+  printf "%s\n" "$*" >> "$FAKE_OPENCODE_LOG"
+  if [[ "$n" -eq 1 ]]; then exit 1; fi
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_abc\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_OPENCODE_COUNT="$STATE_DIR/opencode_count"
+  export FAKE_OPENCODE_LOG="$STATE_DIR/opencode_log"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree"
+  assert_eq "first opencode attempt uses fresh title session" "run --auto --title carbotracker-ticket-10 /implement the issue is 10" "$(sed -n '1p' "$FAKE_OPENCODE_LOG")"
+  assert_eq "retry once with --continue" "run --auto --continue /implement the issue is 10" "$(sed -n '2p' "$FAKE_OPENCODE_LOG")"
+  assert_eq "retried run completes the ticket" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  unset FAKE_OPENCODE_COUNT FAKE_OPENCODE_LOG
+  state_teardown
+}
+
+test_implement_escalates_after_two_opencode_failures() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_EDIT"
+  exit 0
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_COMMENT"
+  exit 0
+fi
+exit 1'
   fake_command git 'if [[ "$1" == "worktree" && "$2" == "add" ]]; then
   mkdir -p "$3"
+elif [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+  rm -rf "$3" "$4"
+elif [[ "$1" == "branch" && "$2" == "-D" ]]; then
+  exit 0
 fi
 exit 0'
   fake_command npm 'exit 0'
   fake_command opencode 'exit 1'
   local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_ESCALATE_EDIT="$STATE_DIR/escalate_edit"
+  export FAKE_ESCALATE_COMMENT="$STATE_DIR/escalate_comment"
   ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
-  if ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" >/dev/null 2>&1; then
-    fail "implement fails when opencode run fails"
-  else
-    pass "implement fails when opencode run fails"
-  fi
+  local output rc
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" 2>&1)" && rc=0 || rc=$?
+  assert_eq "implement fails when opencode fails twice" "no" "$([[ "$rc" -eq 0 ]] && echo yes || echo no)"
+  assert_contains "escalation removes in-progress label" "--remove-label in-progress" "$(cat "$FAKE_ESCALATE_EDIT")"
+  assert_contains "escalation removes ticket label" "--remove-label ticket" "$(cat "$FAKE_ESCALATE_EDIT")"
+  assert_contains "escalation adds needs-triage" "--add-label needs-triage" "$(cat "$FAKE_ESCALATE_EDIT")"
+  assert_contains "escalation comments with failure context" "opencode exited non-zero twice" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  assert_eq "escalation removes the entry from state" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "escalation prunes the worktree" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "logs the escalation" "escalated #10 to needs-triage" "$output"
+  unset FAKE_ESCALATE_EDIT FAKE_ESCALATE_COMMENT
   state_teardown
 }
 
@@ -1574,6 +1696,167 @@ test_state_loaded_but_empty_file() {
   state_teardown
 }
 
+test_reconcile_empty_state_is_noop() {
+  state_setup
+  fake_command gh 'exit 99'
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>&1)"
+  assert_eq "reconcile leaves empty state alone" "0" "$(jq 'length' "$TEST_STATE" 2>/dev/null || echo 0)"
+  assert_contains "logs reconciliation" "reconciling" "$output"
+  state_teardown
+}
+
+test_reconcile_pr_exists_sets_awaiting_review() {
+  state_setup
+  fake_reconcile_gh 456
+  fake_reconcile_git 0 no no
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc ""
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>&1)"
+  assert_eq "existing pr moves phase to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_eq "existing pr number recorded" "456" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  assert_contains "logs pr recovery" "PR #456 exists" "$output"
+  state_teardown
+}
+
+test_reconcile_pushed_branch_creates_pr() {
+  state_setup
+  fake_reconcile_git 0 no yes
+  fake_command npm 'exit 0'
+  fake_reconcile_opencode ses_old
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  if [[ -f "$FAKE_PR_CREATED" ]]; then
+    printf "[{\"number\":50}]\n"
+  else
+    printf "[]\n"
+  fi
+elif [[ "$1" == "pr" && "$2" == "create" ]]; then
+  printf "%s\n" "$*" > "$FAKE_PR_CREATE_ARGS"
+  touch "$FAKE_PR_CREATED"
+elif [[ "$1" == "issue" && "$2" == "view" ]]; then
+  printf "Some Title\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ISSUE_COMMENT_ARGS"
+fi
+exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_PR_CREATED="$STATE_DIR/pr_created"
+  export FAKE_PR_CREATE_ARGS="$STATE_DIR/pr_create"
+  export FAKE_ISSUE_COMMENT_ARGS="$STATE_DIR/issue_comment"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_old ""
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>/dev/null
+  assert_contains "pushed branch creates pr for the branch" "--head ticket/123-foo" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_contains "pushed branch creates pr with base main" "--base main" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_eq "recovered pr number stored" "50" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  assert_eq "recovered entry moves to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_contains "issue commented with created pr" "Started implementation. PR #50 created." "$(cat "$FAKE_ISSUE_COMMENT_ARGS")"
+  unset FAKE_PR_COUNT FAKE_PR_CREATE_ARGS FAKE_ISSUE_COMMENT_ARGS
+  state_teardown
+}
+
+test_reconcile_resumes_with_continue_when_no_session() {
+  state_setup
+  fake_reconcile_git 3 no no
+  fake_command npm 'exit 0'
+  fake_reconcile_opencode ses_r
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  if [[ -f "$FAKE_PR_CREATED" ]]; then
+    printf "[{\"number\":70}]\n"
+  else
+    printf "[]\n"
+  fi
+elif [[ "$1" == "pr" && "$2" == "create" ]]; then
+  printf "%s\n" "$*" > "$FAKE_PR_CREATE_ARGS"
+  touch "$FAKE_PR_CREATED"
+elif [[ "$1" == "issue" && "$2" == "view" ]]; then
+  printf "Some Title\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_PR_CREATED="$STATE_DIR/pr_created"
+  export FAKE_PR_CREATE_ARGS="$STATE_DIR/pr_create"
+  export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>/dev/null
+  assert_contains "unpushed work resumes opencode with --continue" "--continue" "$(cat "$FAKE_OPENCODE_ARGS")"
+  assert_contains "resumed opencode targets the issue" "/implement the issue is 123" "$(cat "$FAKE_OPENCODE_ARGS")"
+  assert_contains "resumed work opens a pr" "--head ticket/123-foo" "$(cat "$FAKE_PR_CREATE_ARGS")"
+  assert_eq "resumed work reaches awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_eq "resumed work records pr number" "70" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  unset FAKE_PR_CREATED FAKE_OPENCODE_ARGS FAKE_PR_CREATE_ARGS
+  state_teardown
+}
+
+test_reconcile_resumes_with_recorded_session() {
+  state_setup
+  fake_reconcile_git 2 yes no
+  fake_command npm 'exit 0'
+  fake_reconcile_opencode ses_old
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  if [[ -f "$FAKE_PR_CREATED" ]]; then
+    printf "[{\"number\":71}]\n"
+  else
+    printf "[]\n"
+  fi
+elif [[ "$1" == "pr" && "$2" == "create" ]]; then
+  touch "$FAKE_PR_CREATED"
+elif [[ "$1" == "issue" && "$2" == "view" ]]; then
+  printf "Some Title\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_PR_CREATED="$STATE_DIR/pr_created"
+  export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_old ""
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>/dev/null
+  assert_contains "recorded session is resumed" "--session ses_old" "$(cat "$FAKE_OPENCODE_ARGS")"
+  assert_eq "dirty worktree reaches awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  unset FAKE_OPENCODE_ARGS
+  state_teardown
+}
+
+test_reconcile_nothing_recoverable_cleans_up() {
+  state_setup
+  fake_reconcile_git 0 no no
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[]\n"
+elif [[ "$1" == "issue" && "$2" == "view" ]]; then
+  printf "Some Title\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ISSUE_COMMENT_ARGS"
+elif [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ISSUE_EDIT_ARGS"
+fi
+exit 0'
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_ISSUE_COMMENT_ARGS="$STATE_DIR/issue_comment"
+  export FAKE_ISSUE_EDIT_ARGS="$STATE_DIR/issue_edit"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_WORKTREE_PARENT="$WT_PARENT" orchestrator_reconcile 2>&1)"
+  assert_eq "unrecoverable entry removed from state" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "unrecoverable worktree removed" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "unrecoverable issue commented" "no recoverable work" "$(cat "$FAKE_ISSUE_COMMENT_ARGS")"
+  assert_contains "unrecoverable issue drops in-progress" "--remove-label in-progress" "$(cat "$FAKE_ISSUE_EDIT_ARGS")"
+  assert_eq "unrecoverable issue is not re-queued" "0" "$(grep -c -- '--add-label ready-for-agent' "$FAKE_ISSUE_EDIT_ARGS")"
+  assert_contains "logs the cleanup" "nothing recoverable" "$output"
+  unset FAKE_ISSUE_COMMENT_ARGS FAKE_ISSUE_EDIT_ARGS
+  state_teardown
+}
+
 test_state_load_missing
 test_state_loaded_but_empty_file
 test_state_complete_updates_entry
@@ -1606,6 +1889,12 @@ test_issue_blocked_via_blocked_by_section
 test_body_blocker_numbers_stops_at_next_section
 test_opencode_session_id_filters_by_title
 test_opencode_session_id_no_match
+test_reconcile_empty_state_is_noop
+test_reconcile_pr_exists_sets_awaiting_review
+test_reconcile_pushed_branch_creates_pr
+test_reconcile_resumes_with_continue_when_no_session
+test_reconcile_resumes_with_recorded_session
+test_reconcile_nothing_recoverable_cleans_up
 test_pr_number_for_branch
 test_pr_number_for_branch_missing
 test_pr_latest_comment_at_returns_newest
@@ -1646,7 +1935,8 @@ test_poll_once_runs_merge_poll
 test_implement_runs_full_pipeline
 test_implement_fails_when_worktree_fails
 test_implement_fails_when_npm_ci_fails
-test_implement_fails_when_opencode_fails
+test_implement_retries_opencode_with_continue
+test_implement_escalates_after_two_opencode_failures
 test_implement_no_pr_skips_comment
 test_implement_no_session_stores_null
 test_implement_opens_pr_when_none_exists


### PR DESCRIPTION
Automated implementation of #221.

- Reconciles state against observable git facts on startup (worktree, branch, git log, PRs)
- Resumes interrupted implementations, creates PRs for pushed branches, recovers to awaiting review when a PR exists, cleans up unrecoverable entries
- Retries `opencode run` once with `--continue`, then escalates to needs-triage with failure context
- `pr list --state all` prevents duplicate PRs; session lookups guarded under `set -euo pipefail`

---
_Created by carbotracker's agent skills._