### PR TITLE
feat(tools): add VPS setup script for the orchestrator daemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ci:check-formatting": "npm run prettier:check",
     "ci:lint": "npx nx affected --target=lint --base=origin/main",
     "ci:test": "npx nx affected --target=test --base=origin/main --codeCoverage=true --coverageReporters=text",
-    "test:tools": "bash tools/tests/ct-lib.test.sh && bash tools/tests/ct-orchestrator.test.sh",
+    "test:tools": "bash tools/tests/ct-lib.test.sh && bash tools/tests/ct-orchestrator.test.sh && bash tools/tests/ct-orchestrator-setup.test.sh",
     "orchestrator:run": "bash tools/ct-orchestrator.sh",
     "orchestrator:once": "bash tools/ct-orchestrator.sh once",
     "ci:build": "npx nx affected --target=build --base=origin/main",

--- a/tools/ct-orchestrator-setup.sh
+++ b/tools/ct-orchestrator-setup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ct-orchestrator-setup.sh — bootstrap a VPS for the carbotracker orchestrator.
+#
+# Running this on a fresh VPS clones the repo, installs the systemd user
+# service unit, enables lingering, and starts the daemon. Idempotent: safe to
+# run repeatedly (an existing clone is pulled, the unit is overwritten, and
+# systemctl enable/start are no-ops when the service is already active).
+#
+# Prerequisites (all must be installed and on PATH):
+#   - gh          GitHub CLI, authenticated with `gh auth login` (repo scope)
+#   - node/npm    Node.js toolchain (used inside ticket worktrees)
+#   - jq          JSON processor used by the daemon scripts
+#   - opencode    The agent that implements tickets
+#   - git, systemctl, loginctl (systemd user session)
+#
+# The repo is cloned over HTTPS by default; gh acts as the git credential
+# helper for later pushes. Override with CARBOTRACKER_REPO_URL.
+
+set -euo pipefail
+
+REPO_URL="${CARBOTRACKER_REPO_URL:-https://github.com/bemerkenswert/carbotracker.git}"
+REPO_DIR="${CARBOTRACKER_REPO_DIR:-$HOME/git/carbotracker}"
+SERVICE_UNIT="carbotracker-orchestrator.service"
+SERVICE_NAME="carbotracker-orchestrator"
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+# Prerequisites that must be installed and on PATH (also documented above).
+PREREQ_TOOLS=(gh git node npm jq opencode systemctl loginctl)
+
+setup_log() {
+  printf '[ct-orchestrator-setup] %s\n' "$*"
+}
+
+check_prereqs() {
+  local missing=0 tool
+  for tool in "$@"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "Error: required tool '$tool' is not installed or not on PATH." >&2
+      missing=1
+    fi
+  done
+  if [[ $missing -eq 1 ]]; then
+    return 1
+  fi
+}
+
+setup_clone() {
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    setup_log "updating existing clone at $REPO_DIR"
+    git -C "$REPO_DIR" remote set-url origin "$REPO_URL"
+    git -C "$REPO_DIR" pull --ff-only
+  else
+    setup_log "cloning $REPO_URL into $REPO_DIR"
+    mkdir -p "$(dirname "$REPO_DIR")"
+    git clone "$REPO_URL" "$REPO_DIR"
+  fi
+}
+
+setup_install_unit() {
+  setup_log "installing systemd user unit $SERVICE_UNIT"
+  mkdir -p "$SYSTEMD_USER_DIR"
+  cp "$REPO_DIR/tools/$SERVICE_UNIT" "$SYSTEMD_USER_DIR/$SERVICE_UNIT"
+}
+
+setup_enable_linger() {
+  setup_log "enabling lingering so the daemon survives logout"
+  loginctl enable-linger
+}
+
+setup_enable_start() {
+  setup_log "reloading the systemd user daemon"
+  systemctl --user daemon-reload
+  setup_log "enabling and starting $SERVICE_NAME"
+  systemctl --user enable --now "$SERVICE_NAME"
+}
+
+setup_verify() {
+  setup_log "verifying $SERVICE_NAME is running"
+  systemctl --user status "$SERVICE_NAME"
+}
+
+setup_help() {
+  echo "Usage:"
+  echo "  ct-orchestrator-setup.sh                Bootstrap the orchestrator on a VPS"
+  echo "  ct-orchestrator-setup.sh help           Show this help"
+}
+
+main() {
+  case "${1:-}" in
+    help | --help | -h)
+      setup_help
+      ;;
+    "")
+      check_prereqs "${PREREQ_TOOLS[@]}"
+      setup_clone
+      setup_install_unit
+      setup_enable_linger
+      setup_enable_start
+      setup_verify
+      ;;
+    *)
+      setup_help >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tools/tests/ct-orchestrator-setup.test.sh
+++ b/tools/tests/ct-orchestrator-setup.test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export ROOT
+source "$ROOT/tools/ct-orchestrator-setup.sh"
+
+failures=0
+tests=0
+
+pass() {
+  printf "ok - %s\n" "$1"
+  tests=$((tests + 1))
+}
+
+fail() {
+  printf "not ok - %s\n" "$1"
+  tests=$((tests + 1))
+  failures=$((failures + 1))
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$desc"
+  else
+    fail "$desc"
+    printf "  expected: %q\n  actual:   %q\n" "$expected" "$actual"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$desc"
+  else
+    fail "$desc"
+    printf "  missing:  %q\n  in:       %q\n" "$needle" "$haystack"
+  fi
+}
+
+FAKE_DIR=""
+ORIG_PATH="$PATH"
+FAKE_GIT_LOG=""
+FAKE_SYSTEMCTL_LOG=""
+FAKE_LOGINCTL_LOG=""
+
+fake_setup() {
+  FAKE_DIR="$(mktemp -d)"
+  FAKE_GIT_LOG="$FAKE_DIR/git.log"
+  FAKE_SYSTEMCTL_LOG="$FAKE_DIR/systemctl.log"
+  FAKE_LOGINCTL_LOG="$FAKE_DIR/loginctl.log"
+  export FAKE_GIT_LOG FAKE_SYSTEMCTL_LOG FAKE_LOGINCTL_LOG
+  ORIG_PATH="$PATH"
+  PATH="$FAKE_DIR:$PATH"
+}
+
+fake_command() {
+  local name="$1" body="$2"
+  printf '%s\n' '#!/usr/bin/env bash' "$body" > "$FAKE_DIR/$name"
+  chmod +x "$FAKE_DIR/$name"
+}
+
+fake_teardown() {
+  PATH="$ORIG_PATH"
+  rm -rf "$FAKE_DIR"
+  FAKE_DIR=""
+}
+
+# Fake git that logs every invocation. On clone it materialises the target
+# directory (including .git) and seeds tools/carbotracker-orchestrator.service
+# from the real repo, so the idempotent second run exercises the pull path.
+fake_git() {
+  fake_command git 'printf "%s\n" "$*" >> "$FAKE_GIT_LOG"
+if [[ "$1" == "clone" ]]; then
+  mkdir -p "$3/tools"
+  cp "$ROOT/tools/carbotracker-orchestrator.service" "$3/tools/carbotracker-orchestrator.service"
+  mkdir -p "$3/.git"
+fi
+exit 0'
+}
+
+# Fake systemctl that logs every invocation; status succeeds.
+fake_systemctl() {
+  fake_command systemctl 'printf "%s\n" "$*" >> "$FAKE_SYSTEMCTL_LOG"
+exit 0'
+}
+
+fake_loginctl() {
+  fake_command loginctl 'printf "%s\n" "$*" >> "$FAKE_LOGINCTL_LOG"
+exit 0'
+}
+
+fake_all_prereqs() {
+  fake_command gh 'exit 0'
+  fake_command git 'exit 0'
+  fake_command node 'exit 0'
+  fake_command npm 'exit 0'
+  fake_command jq 'exit 0'
+  fake_command opencode 'exit 0'
+  fake_command systemctl 'exit 0'
+  fake_command loginctl 'exit 0'
+}
+
+test_check_prereqs_ok() {
+  fake_all_prereqs
+  if check_prereqs gh git node npm jq opencode systemctl loginctl; then
+    pass "prereqs pass when all tools are present"
+  else
+    fail "prereqs pass when all tools are present"
+  fi
+}
+
+test_check_prereqs_missing() {
+  fake_all_prereqs
+  local output
+  output=$(check_prereqs gh git node npm jq opencode systemctl definitely-not-a-tool 2>&1 || true)
+  assert_contains "prereqs fail when a tool is missing" "definitely-not-a-tool" "$output"
+}
+
+test_clone_creates() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  fake_git
+  REPO_DIR="$sandbox/git/carbotracker" setup_clone >/dev/null
+  assert_eq "clone makes the repo dir" "yes" "$([[ -d "$sandbox/git/carbotracker" ]] && echo yes || echo no)"
+  assert_contains "clone invokes git clone" "clone https://github.com/bemerkenswert/carbotracker.git $sandbox/git/carbotracker" "$(cat "$FAKE_GIT_LOG")"
+  rm -rf "$sandbox"
+}
+
+test_clone_pulls_when_exists() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  mkdir -p "$sandbox/git/carbotracker/.git"
+  fake_git
+  REPO_DIR="$sandbox/git/carbotracker" setup_clone >/dev/null
+  if grep -q '^clone ' "$FAKE_GIT_LOG"; then
+    fail "existing clone is not re-cloned"
+  else
+    pass "existing clone is not re-cloned"
+  fi
+  local log
+  log="$(cat "$FAKE_GIT_LOG")"
+  assert_contains "existing clone reapplies the remote" "remote set-url origin https://github.com/bemerkenswert/carbotracker.git" "$log"
+  assert_contains "existing clone pulls" "-C $sandbox/git/carbotracker pull --ff-only" "$log"
+  rm -rf "$sandbox"
+}
+
+test_clone_override() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  fake_git
+  REPO_DIR="$sandbox/git/carbotracker" REPO_URL="https://example.com/fork.git" setup_clone >/dev/null
+  assert_contains "clone honors the URL override" "clone https://example.com/fork.git $sandbox/git/carbotracker" "$(cat "$FAKE_GIT_LOG")"
+  rm -rf "$sandbox"
+}
+
+test_install_unit() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  mkdir -p "$sandbox/git/carbotracker/tools"
+  cp "$ROOT/tools/carbotracker-orchestrator.service" "$sandbox/git/carbotracker/tools/"
+  REPO_DIR="$sandbox/git/carbotracker" SYSTEMD_USER_DIR="$sandbox/systemd/user" setup_install_unit >/dev/null
+  assert_eq "unit installed into systemd user dir" "yes" "$([[ -f "$sandbox/systemd/user/carbotracker-orchestrator.service" ]] && echo yes || echo no)"
+  rm -rf "$sandbox"
+}
+
+test_enable_start() {
+  fake_systemctl
+  setup_enable_start >/dev/null
+  local log
+  log="$(cat "$FAKE_SYSTEMCTL_LOG")"
+  assert_contains "daemon reload invoked" "--user daemon-reload" "$log"
+  assert_contains "service enabled and started" "--user enable --now carbotracker-orchestrator" "$log"
+}
+
+test_verify() {
+  fake_systemctl
+  setup_verify >/dev/null
+  assert_contains "status invoked for the service" "--user status carbotracker-orchestrator" "$(cat "$FAKE_SYSTEMCTL_LOG")"
+}
+
+test_whole_script_idempotent() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  fake_command gh 'exit 0'
+  fake_git
+  fake_command node 'exit 0'
+  fake_command npm 'exit 0'
+  fake_command jq 'exit 0'
+  fake_command opencode 'exit 0'
+  fake_systemctl
+  fake_loginctl
+
+  local home="$sandbox/home"
+  mkdir -p "$home"
+
+  if HOME="$home" CARBOTRACKER_REPO_URL="https://example.com/fork.git" bash "$ROOT/tools/ct-orchestrator-setup.sh" >/dev/null 2>&1; then
+    pass "first run succeeds"
+  else
+    fail "first run succeeds"
+  fi
+
+  assert_eq "first run cloned the repo" "yes" "$([[ -d "$home/git/carbotracker" ]] && echo yes || echo no)"
+  assert_eq "first run installed the unit" "yes" "$([[ -f "$home/.config/systemd/user/carbotracker-orchestrator.service" ]] && echo yes || echo no)"
+  assert_contains "first run clones with the URL override" "clone https://example.com/fork.git $home/git/carbotracker" "$(cat "$FAKE_GIT_LOG")"
+
+  if HOME="$home" CARBOTRACKER_REPO_URL="https://example.com/fork.git" bash "$ROOT/tools/ct-orchestrator-setup.sh" >/dev/null 2>&1; then
+    pass "second run succeeds"
+  else
+    fail "second run succeeds"
+  fi
+
+  local git_log
+  git_log="$(cat "$FAKE_GIT_LOG")"
+  assert_contains "second run does not re-clone" "pull --ff-only" "$git_log"
+  assert_contains "second run reapplies the URL override" "remote set-url origin https://example.com/fork.git" "$git_log"
+  rm -rf "$sandbox"
+}
+
+run_test() {
+  fake_setup
+  "$1"
+  fake_teardown
+}
+
+run_test test_check_prereqs_ok
+run_test test_check_prereqs_missing
+run_test test_clone_creates
+run_test test_clone_pulls_when_exists
+run_test test_clone_override
+run_test test_install_unit
+run_test test_enable_start
+run_test test_verify
+run_test test_whole_script_idempotent
+
+printf '1..%d\n' "$tests"
+if [[ $failures -gt 0 ]]; then
+  printf '%d/%d tests failed\n' "$failures" "$tests"
+  exit 1
+fi
+printf 'all %d tests passed\n' "$tests"


### PR DESCRIPTION
Adds `tools/ct-orchestrator-setup.sh`, a bootstrap script that clones the repo onto a VPS, installs the carbotracker-orchestrator systemd user unit, enables lingering, and starts/verifies the daemon.

Running `bash tools/ct-orchestrator-setup.sh` on a fresh VPS gets the orchestrator running. The script is idempotent (re-runs pull instead of re-clone and no-op on an already-active service) and fails early when a prerequisite is missing.

## Design decisions

- **Clone over HTTPS** (`CARBOTRACKER_REPO_URL` override); gh acts as the git credential helper for later pushes.
- **No `npm ci` in the main clone** — deliberate deviation from the ticket AC: the daemon is pure bash and never uses the main clone's node_modules; per-ticket worktrees install their own dependencies.
- **Prereq check fails fast** — verifies gh, git, node/npm, jq, opencode, systemctl, loginctl before doing anything, rather than only documenting them.
- **Service unit copied from the clone**, so a curl'd script works on a fresh VPS without sibling files.
- **`loginctl enable-linger`** so the user service survives logout and starts at boot on a headless VPS.

## Testing

19 new tests in `tools/tests/ct-orchestrator-setup.test.sh` (clone/pull, URL override, unit install, enable/start, verify, prereq check, whole-script idempotency), wired into `npm run test:tools`.

Closes #222