### PR TITLE
Require the spec label in the to-spec skill

### DIFF
--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -18,6 +18,14 @@ Check with the user that these seams match their expectations.
 
 3. Write the spec using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
 
+<!-- BEGIN carbotracker-local: keep this block intact when merging upstream skill updates -->
+
+Also apply the `spec` label (see `docs/agents/triage-labels.md`): specs and
+PRDs carry `spec`, never `ticket`. The `ai-created` label and body footer from
+`docs/agents/issue-tracker.md` apply to every agent-created issue as usual.
+
+<!-- END carbotracker-local -->
+
 <spec-template>
 
 ## Problem Statement


### PR DESCRIPTION
The repo's triage vocabulary marks specs and PRDs with the `spec` label (`docs/agents/triage-labels.md`), but the to-spec skill only instructed agents to apply `ready-for-agent` — which is how #308 was published without `spec`. The skill now carries a carbotracker-local block with the repo label rules, marked with the same `BEGIN carbotracker-local`/`END carbotracker-local` convention the implement skill uses (hand-written maintainer adjustment, preserved on upstream skill updates).