### PR TITLE
Implement Migrate current-meal's remaining specs to the testing standard (#298)

### DIFF
--- a/apps/carbotracker/src/features/current-meal/+state/current-meal.store.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/current-meal.store.spec.ts
@@ -1,5 +1,6 @@
 import { Product } from '../../../features/products/product.model';
 import { MealEntry } from '../current-meal.model';
+import { CreateMealEntryPageComponentActions } from './actions/component.actions';
 import { CurrentMealApiActions } from './actions/api.actions';
 import { currentMealFeature, getInitialState } from './current-meal.store';
 
@@ -18,51 +19,90 @@ describe('currentMealFeature', () => {
     carbs: 50,
   });
 
-  describe('selectCurrentMealIsEmpty', () => {
-    it('is true when there are no meal entries', () => {
-      const state = getInitialState();
-      const mealEntries = currentMealFeature.selectAllMealEntries.projector(
-        currentMealFeature.selectMealEntries.projector(state),
-      );
-      const result =
-        currentMealFeature.selectCurrentMealIsEmpty.projector(mealEntries);
-      expect(result).toBe(true);
-    });
+  it('returns the initial state for an unknown action', () => {
+    const initialState = getInitialState();
+    const action = { type: 'Unknown' };
 
-    it('is false when the current meal has entries', () => {
-      const state = currentMealFeature.reducer(
-        getInitialState(),
-        CurrentMealApiActions.currentMealCollectionChanged({
-          currentMeal: { mealEntries: [createMealEntry('p1', 100)] },
-        }),
-      );
-      const mealEntries = currentMealFeature.selectAllMealEntries.projector(
-        currentMealFeature.selectMealEntries.projector(state),
-      );
-      const result =
-        currentMealFeature.selectCurrentMealIsEmpty.projector(mealEntries);
-      expect(result).toBe(false);
-    });
+    const state = currentMealFeature.reducer(initialState, action);
+
+    expect(state).toBe(initialState);
   });
 
-  describe('selectNotAddedProducts', () => {
-    it('excludes products that already have an entry in the current meal', () => {
-      const mealEntryIds = currentMealFeature.selectAllMealEntryIds.projector(
-        currentMealFeature.selectMealEntries.projector(
-          currentMealFeature.reducer(
-            getInitialState(),
-            CurrentMealApiActions.currentMealCollectionChanged({
-              currentMeal: { mealEntries: [createMealEntry('p1', 100)] },
-            }),
-          ),
-        ),
-      );
+  it('stores the product search term when it changes', () => {
+    const state = currentMealFeature.reducer(
+      getInitialState(),
+      CreateMealEntryPageComponentActions.productSearchTermChanged({
+        productSearchTerm: 'spaghetti',
+      }),
+    );
 
-      const result = currentMealFeature.selectNotAddedProducts.projector(
-        [createProduct('p1'), createProduct('p2')],
-        mealEntryIds,
-      );
-      expect(result).toEqual([createProduct('p2')]);
-    });
+    const productSearchTerm =
+      currentMealFeature.selectProductSearchTerm.projector(state);
+
+    expect(productSearchTerm).toBe('spaghetti');
+  });
+
+  it('stores the meal entries when the collection changes', () => {
+    const state = currentMealFeature.reducer(
+      getInitialState(),
+      CurrentMealApiActions.currentMealCollectionChanged({
+        currentMeal: { mealEntries: [createMealEntry('p1', 100)] },
+      }),
+    );
+
+    const mealEntries = currentMealFeature.selectAllMealEntries.projector(
+      currentMealFeature.selectMealEntries.projector(state),
+    );
+
+    expect(mealEntries).toEqual([createMealEntry('p1', 100)]);
+  });
+
+  it('is empty when there are no meal entries', () => {
+    const state = getInitialState();
+    const mealEntries = currentMealFeature.selectAllMealEntries.projector(
+      currentMealFeature.selectMealEntries.projector(state),
+    );
+
+    const result =
+      currentMealFeature.selectCurrentMealIsEmpty.projector(mealEntries);
+
+    expect(result).toBe(true);
+  });
+
+  it('is not empty when the current meal has entries', () => {
+    const state = currentMealFeature.reducer(
+      getInitialState(),
+      CurrentMealApiActions.currentMealCollectionChanged({
+        currentMeal: { mealEntries: [createMealEntry('p1', 100)] },
+      }),
+    );
+    const mealEntries = currentMealFeature.selectAllMealEntries.projector(
+      currentMealFeature.selectMealEntries.projector(state),
+    );
+
+    const result =
+      currentMealFeature.selectCurrentMealIsEmpty.projector(mealEntries);
+
+    expect(result).toBe(false);
+  });
+
+  it('excludes products that already have an entry in the current meal', () => {
+    const mealEntryIds = currentMealFeature.selectAllMealEntryIds.projector(
+      currentMealFeature.selectMealEntries.projector(
+        currentMealFeature.reducer(
+          getInitialState(),
+          CurrentMealApiActions.currentMealCollectionChanged({
+            currentMeal: { mealEntries: [createMealEntry('p1', 100)] },
+          }),
+        ),
+      ),
+    );
+
+    const result = currentMealFeature.selectNotAddedProducts.projector(
+      [createProduct('p1'), createProduct('p2')],
+      mealEntryIds,
+    );
+
+    expect(result).toEqual([createProduct('p2')]);
   });
 });

--- a/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
@@ -1,27 +1,41 @@
-import { Action } from '@ngrx/store';
+import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { Subject, of } from 'rxjs';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
+import { of, Subject } from 'rxjs';
 import { CurrentMealApiActions } from '../actions/api.actions';
 import {
-  EditMealEntryPageComponentActions,
   CreateMealEntryPageComponentActions,
+  EditMealEntryPageComponentActions,
 } from '../actions/component.actions';
 import { CurrentMealRouterEffectsActions } from '../actions/routing.actions';
 import { navigateToCurrentMeal$ } from './routing.effects';
 
-const buildRouter = (): Router =>
-  ({
-    navigate: jest.fn(() => of(true)),
-  }) as unknown as Router;
-
 describe('navigateToCurrentMeal$', () => {
+  let actions$: Subject<Action>;
+  let router: jest.Mocked<Router>;
+
+  beforeEach(() => {
+    actions$ = new Subject<Action>();
+    router = {
+      navigate: jest.fn(() => of(true)),
+    } as unknown as jest.Mocked<Router>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockActions(() => actions$),
+        provideMockStore(),
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
   it('navigates to the current meal page after a meal entry is added successfully', () => {
-    const router = buildRouter();
-    const actions$ = new Subject<Action>();
     const results: Action[] = [];
 
-    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe(
-      (action) => results.push(action),
+    TestBed.runInInjectionContext(() =>
+      navigateToCurrentMeal$().subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
@@ -33,10 +47,7 @@ describe('navigateToCurrentMeal$', () => {
   });
 
   it('does not navigate on the create meal entry page save click', () => {
-    const router = buildRouter();
-    const actions$ = new Subject<Action>();
-
-    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe();
+    TestBed.runInInjectionContext(() => navigateToCurrentMeal$().subscribe());
 
     actions$.next(
       CreateMealEntryPageComponentActions.saveClicked({
@@ -54,12 +65,10 @@ describe('navigateToCurrentMeal$', () => {
   });
 
   it('navigates to the current meal page on edit meal entry page actions', () => {
-    const router = buildRouter();
-    const actions$ = new Subject<Action>();
     const results: Action[] = [];
 
-    navigateToCurrentMeal$(actions$.asObservable(), router).subscribe(
-      (action) => results.push(action),
+    TestBed.runInInjectionContext(() =>
+      navigateToCurrentMeal$().subscribe((action) => results.push(action)),
     );
 
     actions$.next(EditMealEntryPageComponentActions.goBackIconClicked());

--- a/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
@@ -1,5 +1,8 @@
+import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
 import { Observable, of, Subject } from 'rxjs';
 import { CurrentMealApiActions } from '../actions/api.actions';
 import { CurrentMealSnackBarActions } from '../actions/snackbar.actions';
@@ -12,122 +15,134 @@ import {
   showSaveCurrentMealSuccessfulSnackbar$,
 } from './snackbar.effects';
 
-const buildSnackBar = (): MatSnackBar =>
-  ({
-    open: jest.fn().mockReturnValue({
-      afterOpened: jest.fn().mockReturnValue(of(undefined)),
-    }),
-  }) as unknown as MatSnackBar;
-
-const buildEffect = (
-  effect: (
-    actions$: Observable<Action>,
-    snackBar: MatSnackBar,
-  ) => Observable<Action>,
-) => {
-  const actions$ = new Subject<Action>();
-  const snackBar = buildSnackBar();
-  const results: Action[] = [];
-  effect(actions$.asObservable(), snackBar).subscribe((action) =>
-    results.push(action),
-  );
-  return { actions$, snackBar, results };
-};
-
 describe('snackbar effects', () => {
-  it('shows the add meal entry success snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showAddMealEntrySuccessfulSnackbar$,
+  let actions$: Subject<Action>;
+  let snackBar: jest.Mocked<MatSnackBar>;
+
+  const run = (effect: () => Observable<Action>): Action[] => {
+    const results: Action[] = [];
+
+    TestBed.runInInjectionContext(() =>
+      effect().subscribe((action) => results.push(action)),
     );
 
-    actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
+    return results;
+  };
 
-    expect(snackBar.open).toHaveBeenCalledWith('The meal entry was added.');
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showAddMealEntrySnackbarSuccessful(),
-    ]);
+  beforeEach(() => {
+    actions$ = new Subject<Action>();
+    const afterOpened = jest.fn(() => of(void 0));
+    snackBar = {
+      open: jest.fn(() => ({ afterOpened })),
+    } as unknown as jest.Mocked<MatSnackBar>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockActions(() => actions$),
+        provideMockStore(),
+        { provide: MatSnackBar, useValue: snackBar },
+      ],
+    });
   });
 
-  it('shows the add meal entry failure snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showAddMealEntryFailedSnackbar$,
-    );
+  describe('showAddMealEntrySuccessfulSnackbar$', () => {
+    it('shows the add meal entry success snackbar', () => {
+      const results = run(() => showAddMealEntrySuccessfulSnackbar$());
 
-    actions$.next(CurrentMealApiActions.addMealEntryFailed({ error: 'boom' }));
+      actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
 
-    expect(snackBar.open).toHaveBeenCalledWith(
-      'The meal entry could not be added.',
-    );
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showAddMealEntrySnackbarFailed(),
-    ]);
+      expect(snackBar.open).toHaveBeenCalledWith('The meal entry was added.');
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showAddMealEntrySnackbarSuccessful(),
+      ]);
+    });
+
+    it('does not show the add meal entry snackbar for other actions', () => {
+      const results = run(() => showAddMealEntrySuccessfulSnackbar$());
+
+      actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
+
+      expect(snackBar.open).not.toHaveBeenCalled();
+      expect(results).toEqual([]);
+    });
   });
 
-  it('shows the clear current meal success snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showClearCurrentMealSuccessfulSnackbar$,
-    );
+  describe('showAddMealEntryFailedSnackbar$', () => {
+    it('shows the add meal entry failure snackbar', () => {
+      const results = run(() => showAddMealEntryFailedSnackbar$());
 
-    actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
+      actions$.next(
+        CurrentMealApiActions.addMealEntryFailed({ error: 'boom' }),
+      );
 
-    expect(snackBar.open).toHaveBeenCalledWith('The current meal was cleared.');
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showClearCurrentMealSnackbarSuccessful(),
-    ]);
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The meal entry could not be added.',
+      );
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showAddMealEntrySnackbarFailed(),
+      ]);
+    });
   });
 
-  it('shows the clear current meal failure snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showClearCurrentMealFailedSnackbar$,
-    );
+  describe('showClearCurrentMealSuccessfulSnackbar$', () => {
+    it('shows the clear current meal success snackbar', () => {
+      const results = run(() => showClearCurrentMealSuccessfulSnackbar$());
 
-    actions$.next(
-      CurrentMealApiActions.clearCurrentMealFailed({ error: 'boom' }),
-    );
+      actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
 
-    expect(snackBar.open).toHaveBeenCalledWith(
-      'The current meal could not be cleared.',
-    );
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showClearCurrentMealSnackbarFailed(),
-    ]);
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The current meal was cleared.',
+      );
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showClearCurrentMealSnackbarSuccessful(),
+      ]);
+    });
   });
 
-  it('does not show the add meal entry snackbar for other actions', () => {
-    const { actions$, snackBar } = buildEffect(
-      showAddMealEntrySuccessfulSnackbar$,
-    );
+  describe('showClearCurrentMealFailedSnackbar$', () => {
+    it('shows the clear current meal failure snackbar', () => {
+      const results = run(() => showClearCurrentMealFailedSnackbar$());
 
-    actions$.next(CurrentMealApiActions.clearCurrentMealSuccessful());
+      actions$.next(
+        CurrentMealApiActions.clearCurrentMealFailed({ error: 'boom' }),
+      );
 
-    expect(snackBar.open).not.toHaveBeenCalled();
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The current meal could not be cleared.',
+      );
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showClearCurrentMealSnackbarFailed(),
+      ]);
+    });
   });
 
-  it('shows the save current meal success snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showSaveCurrentMealSuccessfulSnackbar$,
-    );
+  describe('showSaveCurrentMealSuccessfulSnackbar$', () => {
+    it('shows the save current meal success snackbar', () => {
+      const results = run(() => showSaveCurrentMealSuccessfulSnackbar$());
 
-    actions$.next(CurrentMealApiActions.saveCurrentMealSuccessful());
+      actions$.next(CurrentMealApiActions.saveCurrentMealSuccessful());
 
-    expect(snackBar.open).toHaveBeenCalledWith('The meal was saved.');
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showSaveCurrentMealSnackbarSuccessful(),
-    ]);
+      expect(snackBar.open).toHaveBeenCalledWith('The meal was saved.');
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showSaveCurrentMealSnackbarSuccessful(),
+      ]);
+    });
   });
 
-  it('shows the save current meal failure snackbar', () => {
-    const { actions$, snackBar, results } = buildEffect(
-      showSaveCurrentMealFailedSnackbar$,
-    );
+  describe('showSaveCurrentMealFailedSnackbar$', () => {
+    it('shows the save current meal failure snackbar', () => {
+      const results = run(() => showSaveCurrentMealFailedSnackbar$());
 
-    actions$.next(
-      CurrentMealApiActions.saveCurrentMealFailed({ error: 'boom' }),
-    );
+      actions$.next(
+        CurrentMealApiActions.saveCurrentMealFailed({ error: 'boom' }),
+      );
 
-    expect(snackBar.open).toHaveBeenCalledWith('The meal could not be saved.');
-    expect(results).toEqual([
-      CurrentMealSnackBarActions.showSaveCurrentMealSnackbarFailed(),
-    ]);
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'The meal could not be saved.',
+      );
+      expect(results).toEqual([
+        CurrentMealSnackBarActions.showSaveCurrentMealSnackbarFailed(),
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Automated implementation of #298.

---
_Created by carbotracker's agent skills._