### PR TITLE
Implement Non-opencode retry cleanup destroys branches with unpushed commits (#317)

### DIFF
--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -870,11 +870,19 @@ _Created by carbotracker's agent skills._"; then
   done < <(orchestrator_awaiting_review_entries)
 }
 
+# Drop a ticket's state entry and persisted review plan. The shared tail of the
+# prune and preserve-work escalation paths: both end a ticket's lifecycle in the
+# pipeline, differing only in whether the worktree/branch survive.
+orchestrator_drop_state_entry() {
+  local number="$1"
+  orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
+  rm -f "$(dirname "$ORCHESTRATOR_STATE_FILE")/review-plan-$number.json"
+}
+
 orchestrator_prune_ticket() {
   local number="$1" branch="$2" worktree="$3" stash_entry="${4:-}"
   orchestrator_cleanup_worktree "$worktree" "$branch"
-  orchestrator_state_remove "$ORCHESTRATOR_STATE_FILE" "$number"
-  rm -f "$(dirname "$ORCHESTRATOR_STATE_FILE")/review-plan-$number.json"
+  orchestrator_drop_state_entry "$number"
   if [[ -n "$stash_entry" ]]; then
     orchestrator_log "pruned #$number: worktree removed, branch deleted, removed from state; uncommitted work stashed as $stash_entry"
   else
@@ -1264,14 +1272,24 @@ orchestrator_resume_stalled_run() {
 # enforced in one place.
 orchestrator_escalate_opencode_failure() {
   local number="$1" branch="$2" worktree="$3" log_file="$4" reason="$5"
+  local preserve_work=""
   CT_IMPLEMENTATION_FAILURE_KIND=opencode
-  orchestrator_escalate_failure "$number" "$branch" "$worktree" "$log_file" "$reason"
+  # A retry that hits an opencode failure in a worktree whose branch holds
+  # unpushed commits (e.g. a push/PR failure was preserved for the retry) must
+  # not destroy those commits: escalate with the worktree and branch kept so
+  # the committed work survives for a human. Commit-less failures (empty or
+  # stalled runs) prune as before — their uncommitted work is protected by the
+  # stash.
+  if orchestrator_branch_has_commits "$worktree" "$branch"; then
+    preserve_work=preserve
+  fi
+  orchestrator_escalate_failure "$number" "$branch" "$worktree" "$log_file" "$reason" "$preserve_work"
   rm -f "$log_file"
   return 1
 }
 
 orchestrator_escalate_failure() {
-  local number="$1" branch="$2" worktree="$3" log_file="$4" reason="$5"
+  local number="$1" branch="$2" worktree="$3" log_file="$4" reason="$5" preserve_work="${6:-}"
   local tail body stash_entry
   # Stash before posting so the escalation comment can name the entry. When the
   # stash fails the escalation is deferred: pruning would destroy the very work
@@ -1282,7 +1300,17 @@ orchestrator_escalate_failure() {
   tail="$(tail -n 30 "$log_file" 2>/dev/null || true)"
   body="Automated implementation of #$number failed: $reason. Escalated to needs-triage for human review."
   if [[ -n "$stash_entry" ]]; then
-    body+=$'\n'"Uncommitted work was stashed before pruning: \`${stash_entry}\`."
+    if [[ "$preserve_work" == "preserve" ]]; then
+      body+=$'\n'"Uncommitted work was stashed for recovery: \`${stash_entry}\`."
+    else
+      body+=$'\n'"Uncommitted work was stashed before pruning: \`${stash_entry}\`."
+    fi
+  fi
+  if [[ "$preserve_work" == "preserve" ]]; then
+    # The branch holds unpushed commits (a push/PR failure): pruning would
+    # destroy committed work, so the worktree and branch are left in place and
+    # the comment names them for a human to recover.
+    body+=$'\n'"Committed work was preserved: branch \`${branch}\` and worktree \`${worktree}\` were left in place."
   fi
   if [[ -n "$tail" ]]; then
     body+="$(printf '\n```\n%s\n```' "$tail")"
@@ -1290,8 +1318,13 @@ orchestrator_escalate_failure() {
   body+=$'\n---\n_Created by carbotracker\'s agent skills._'
   if gh issue edit "$number" --remove-label "$ORCHESTRATOR_IN_PROGRESS_LABEL" --remove-label ticket --add-label needs-triage \
     && gh issue comment "$number" --body "$body"; then
-    orchestrator_prune_ticket "$number" "$branch" "$worktree" "$stash_entry"
-    orchestrator_log "escalated #$number to needs-triage after $reason; pruned worktree and removed from state"
+    if [[ "$preserve_work" == "preserve" ]]; then
+      orchestrator_drop_state_entry "$number"
+      orchestrator_log "escalated #$number to needs-triage after $reason; kept worktree and branch with their commits"
+    else
+      orchestrator_prune_ticket "$number" "$branch" "$worktree" "$stash_entry"
+      orchestrator_log "escalated #$number to needs-triage after $reason; pruned worktree and removed from state"
+    fi
     return 0
   fi
   orchestrator_restore_stash_after_failed_escalation "$number" "$worktree" "$stash_entry"
@@ -1313,13 +1346,22 @@ orchestrator_restore_failed_labels() {
 
 orchestrator_handle_non_opencode_failure() {
   local number="$1" branch="$2" worktree="$3" reason="$4"
-  local failures retries
+  local failures retries preserve_work
   retries="$ORCHESTRATOR_IMPLEMENTATION_RETRIES"
   orchestrator_state_mark_failed "$ORCHESTRATOR_STATE_FILE" "$number"
   failures="$(orchestrator_state_failure_count "$ORCHESTRATOR_STATE_FILE" "$number")"
+  # A failure after the branch holds unpushed commits (push/PR setup) must
+  # never destroy those commits: the worktree and branch are kept so the retry
+  # can reuse them. Failures that genuinely left nothing behind (worktree
+  # creation, dependency install) clean up exactly as before.
+  if orchestrator_worktree_has_work "$worktree" "$branch"; then
+    preserve_work=preserve
+  else
+    preserve_work=""
+  fi
   if [[ "$failures" -ge "$retries" ]]; then
     orchestrator_escalate_failure "$number" "$branch" "$worktree" "" \
-      "non-opencode failure (attempt $failures/$retries): $reason"
+      "non-opencode failure (attempt $failures/$retries): $reason" "$preserve_work"
     return
   fi
 
@@ -1328,7 +1370,9 @@ orchestrator_handle_non_opencode_failure() {
   else
     orchestrator_log "WARNING: failed to restore ready-for-agent on #$number; it will need manual re-labelling"
   fi
-  if [[ "${CT_WORKTREE_CREATED:-0}" == "1" ]]; then
+  if [[ "$preserve_work" == "preserve" ]]; then
+    orchestrator_log "keeping #$number worktree and branch for the retry: unpushed commits survive"
+  elif [[ "${CT_WORKTREE_CREATED:-0}" == "1" ]]; then
     orchestrator_cleanup_worktree "$worktree" "$branch"
   else
     orchestrator_log "not cleaning up pre-existing worktree $worktree"
@@ -1368,7 +1412,14 @@ orchestrator_implement() {
   CT_IMPLEMENTATION_FAILURE_KIND=non-opencode
 
   orchestrator_log "implementing #$number: creating worktree $worktree (branch $branch)"
-  if ! ct_worktree_add "$worktree" "$branch"; then
+  # A previous non-opencode failure (push/PR setup) left the worktree and branch
+  # in place to preserve unpushed commits; reuse it instead of failing on the
+  # worktree-already-exists guard inside ct_worktree_add. CT_WORKTREE_CREATED
+  # stays 0 for a reused worktree, so a later clean-up only ever removes
+  # worktrees this run actually created.
+  if [[ -d "$worktree" ]] && git -C "$worktree" rev-parse --verify -q "refs/heads/$branch" >/dev/null 2>&1; then
+    orchestrator_log "reusing worktree $worktree (branch $branch) from a previous non-opencode retry"
+  elif ! ct_worktree_add "$worktree" "$branch"; then
     orchestrator_log "ERROR: worktree creation failed for #$number"
     return 1
   fi

--- a/tools/orchestrator.md
+++ b/tools/orchestrator.md
@@ -491,10 +491,15 @@ flowchart TD
     J --> K[gh pr list --head branch → prNumber]
     K --> L[state: sessionId + prNumber, phase awaiting review]
     L --> M[gh issue comment: Started implementation. PR #N created.]
-    F -- failure --> N[failureCount++, phase failed, un-claim + clean up]
-    N --> N1{failureCount below bound?}
-    N1 -- yes --> N2[restore ready-for-agent; retry on next poll]
+    F -- failure --> N[failureCount++, phase failed, un-claim]
+    N --> N0{unpushed commits / work in worktree?}
+    N0 -- yes --> N3[keep worktree and branch for the retry]
+    N0 -- no --> N4[remove worktree and branch]
+    N3 --> N1{failureCount below bound?}
+    N4 --> N1
+    N1 -- yes --> N2[restore ready-for-agent; retry reuses the worktree on next poll]
     N1 -- no --> F4
+    N3 -- no (at bound) --> F4[escalate: needs-triage, stash uncommitted work, comment naming branch/worktree; keep worktree and branch]
     M --> O[merge poll: walk awaiting-review entries]
     O --> P0[gh pr view n → state]
     P0 -- MERGED --> P1[close issue: PR #n merged. Issue closed. → prune worktree/branch, remove from state]
@@ -560,16 +565,25 @@ Follow the daemon with `journalctl --user -u carbotracker-orchestrator -f`.
   `ct_ticket_worktree` helpers (in `ct-lib.sh`) and handed to
   `ct_worktree_add`, so the state file, the actual worktree, and the recovery
   tool can never derive different paths for the same ticket.
-- A failed step records a `failed` state and removes the worktree and branch, so
-  the next poll starts clean while the failure count survives a restart. Below
-  the implementation retry bound the ticket is restored to `ready-for-agent`;
-  at the bound it is escalated to `needs-triage`. Cleanup is guarded:
-  only a worktree this run actually created (`CT_WORKTREE_CREATED`) is
-  removed, so a parallel orchestrator that loses the claim race never deletes
-  the winner's worktree. When `opencode` itself fails, the failure is not
-  retried by re-claiming: the run is retried once in place with `--continue`,
-  then the ticket is escalated to `needs-triage` so a broken ticket stops
-  consuming pipeline effort (see [opencode failures](#opencode-failures)).
+- A failed step records a `failed` state. Below the implementation retry bound
+  the ticket is restored to `ready-for-agent`; at the bound it is escalated to
+  `needs-triage`. Cleanup depends on whether the failure left recoverable work:
+  when the branch holds unpushed commits (a push/PR failure after the agent
+  committed), the worktree and branch are **kept** so the retry reuses them and
+  their commits survive; only a failure that genuinely left nothing behind
+  (worktree creation, dependency install) removes the worktree and branch. The
+  at-bound escalation of a commit-producing failure preserves the work too:
+  the comment names the branch and worktree for a human, and the entry is
+  dropped from state without pruning. Cleanup is guarded: only a worktree this
+  run actually created (`CT_WORKTREE_CREATED`) is removed, so a parallel
+  orchestrator that loses the claim race never deletes the winner's worktree.
+  When `opencode` itself fails, the failure is not retried by re-claiming: the
+  run is retried once in place with `--continue`, then the ticket is escalated
+  to `needs-triage` so a broken ticket stops consuming pipeline effort (see
+  [opencode failures](#opencode-failures)). That opencode escalation preserves
+  the worktree and branch whenever the branch holds unpushed commits, so a
+  retry that fails inside opencode never destroys the preserved commits
+  either.
 - Recovery never trusts the state file's phase: `orchestrator_reconcile`
   derives the phase from `git status`, `git log`, `git ls-remote`, and
   `gh pr list --state all`. `prNumber` from the state file is ignored in

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -1259,6 +1259,49 @@ exit 0'
   state_teardown
 }
 
+test_implement_escalates_opencode_failure_preserves_commits() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_EDIT"
+  exit 0
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_COMMENT"
+  exit 0
+fi
+exit 1'
+  fake_command git 'if [[ "$1" == "-C" ]]; then shift 2; fi
+if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  mkdir -p "$3"
+elif [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+  rm -rf "$3" "$4"
+elif [[ "$1" == "rev-parse" ]]; then
+  exit 0
+elif [[ "$1" == "rev-list" ]]; then
+  printf "1\n"
+elif [[ "$1" == "stash" ]]; then
+  printf "%s\n" "$*" >> "${FAKE_GIT_STASH_ARGS:-/dev/null}"
+elif [[ "$1" == "branch" && "$2" == "-D" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_command npm 'exit 0'
+  fake_command opencode 'exit 1'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  export FAKE_ESCALATE_EDIT="$STATE_DIR/escalate_edit"
+  export FAKE_ESCALATE_COMMENT="$STATE_DIR/escalate_comment"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  local output rc
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" 2>&1)" && rc=0 || rc=$?
+  assert_eq "opencode failure on a branch with commits fails the round" "no" "$([[ "$rc" -eq 0 ]] && echo yes || echo no)"
+  assert_eq "opencode failure on a branch with commits keeps the worktree" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "opencode failure on a branch with commits removes the state entry" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "opencode failure on a branch with commits names the preserved branch" "ticket/10-alpha" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  assert_contains "opencode failure on a branch with commits says the work was preserved" "Committed work was preserved" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  assert_contains "opencode failure on a branch with commits still adds needs-triage" "--add-label needs-triage" "$(cat "$FAKE_ESCALATE_EDIT")"
+  unset FAKE_ESCALATE_EDIT FAKE_ESCALATE_COMMENT
+  state_teardown
+}
+
 test_implement_escalates_empty_run_without_resume() {
   state_setup
   fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
@@ -1779,6 +1822,126 @@ test_non_opencode_failure_escalates_at_bound() {
   assert_contains "bound failure adds triage label" "--add-label needs-triage" "$(cat "$FAKE_ESCALATE_EDIT")"
   assert_contains "bound failure posts comment" "attempt 2/2" "$(cat "$FAKE_ESCALATE_COMMENT")"
   unset FAKE_ESCALATE_EDIT FAKE_ESCALATE_COMMENT
+  state_teardown
+}
+
+test_non_opencode_failure_preserves_worktree_below_bound() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_RETRY_EDIT"
+fi
+exit 0'
+  fake_stalled_git
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  mkdir -p "$worktree"
+  export FAKE_REVLIST_SEQ="$STATE_DIR/revlist"
+  printf '1\n' > "$FAKE_REVLIST_SEQ"
+  export FAKE_RETRY_EDIT="$STATE_DIR/retry_edit"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_IMPLEMENTATION_RETRIES=3 \
+    orchestrator_handle_non_opencode_failure 10 "$branch" "$worktree" "push failed" 2>&1)"
+  assert_eq "push-failure retry keeps the worktree" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "push-failure retry keeps the state entry" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "push-failure retry keeps the failed phase" "failed" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_contains "push-failure retry restores ready-for-agent" "--add-label ready-for-agent" "$(cat "$FAKE_RETRY_EDIT")"
+  assert_contains "push-failure retry logs the preserved worktree" "keeping #10 worktree and branch" "$output"
+  unset FAKE_REVLIST_SEQ FAKE_RETRY_EDIT
+  state_teardown
+}
+
+test_non_opencode_failure_at_bound_preserves_commits() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_EDIT"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  printf "%s\n" "$*" > "$FAKE_ESCALATE_COMMENT"
+fi
+exit 0'
+  fake_stalled_git
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  mkdir -p "$worktree"
+  export FAKE_REVLIST_SEQ="$STATE_DIR/revlist"
+  printf '1\n' > "$FAKE_REVLIST_SEQ"
+  export FAKE_ESCALATE_EDIT="$STATE_DIR/escalate_edit" FAKE_ESCALATE_COMMENT="$STATE_DIR/escalate_comment"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_IMPLEMENTATION_RETRIES=1 \
+    orchestrator_handle_non_opencode_failure 10 "$branch" "$worktree" "push failed" >/dev/null 2>&1
+  assert_eq "at-bound push failure removes the state entry" "0" "$(jq 'length' "$TEST_STATE")"
+  assert_eq "at-bound push failure keeps the worktree" "yes" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_contains "at-bound push failure adds triage label" "--add-label needs-triage" "$(cat "$FAKE_ESCALATE_EDIT")"
+  assert_contains "at-bound push failure names the preserved branch" "ticket/10-alpha" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  assert_contains "at-bound push failure names the preserved worktree" "$worktree" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  assert_contains "at-bound push failure says the work was preserved" "Committed work was preserved" "$(cat "$FAKE_ESCALATE_COMMENT")"
+  unset FAKE_REVLIST_SEQ FAKE_ESCALATE_EDIT FAKE_ESCALATE_COMMENT
+  state_teardown
+}
+
+test_non_opencode_failure_clean_failure_still_cleans_up() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_command git 'if [[ "$1" == "-C" ]]; then shift 2; fi
+if [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+  rm -rf "$3" "$4"
+elif [[ "$1" == "rev-list" ]]; then
+  printf "0\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  mkdir -p "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  export CT_WORKTREE_CREATED=1
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" ORCHESTRATOR_IMPLEMENTATION_RETRIES=3 \
+    orchestrator_handle_non_opencode_failure 10 "$branch" "$worktree" "npm ci failed" 2>&1)"
+  assert_eq "clean failure still removes the worktree" "no" "$([[ -d "$worktree" ]] && echo yes || echo no)"
+  assert_eq "clean failure keeps the state entry" "1" "$(jq 'length' "$TEST_STATE")"
+  assert_contains "clean failure still keeps the failed phase" "kept #10 in failed phase" "$output"
+  unset CT_WORKTREE_CREATED
+  state_teardown
+}
+
+test_implement_reuses_existing_worktree_on_retry() {
+  state_setup
+  fake_command gh 'if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf "[{\"number\":42}]\n"
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  exit 0
+fi
+exit 0'
+  fake_command git 'full_args="$*"
+if [[ "$1" == "-C" ]]; then shift 2; fi
+if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  exit 1
+elif [[ "$1" == "rev-parse" ]]; then
+  exit 0
+elif [[ "$1" == "rev-list" ]]; then
+  printf "1\n"
+elif [[ "$1" == "push" && -n "${FAKE_GIT_PUSH_FILE:-}" ]]; then
+  printf "%s\n" "$full_args" > "$FAKE_GIT_PUSH_FILE"
+fi
+exit 0'
+  fake_command npm 'exit 0'
+  fake_command opencode 'if [[ "$1" == "run" ]]; then
+  exit 0
+elif [[ "$1" == "session" ]]; then
+  printf "[{\"id\":\"ses_abc\",\"title\":\"carbotracker-ticket-10\",\"created\":1}]\n"
+fi
+exit 0'
+  local branch="ticket/10-alpha" worktree="$WT_PARENT/10-alpha"
+  mkdir -p "$worktree"
+  export FAKE_GIT_PUSH_FILE="$STATE_DIR/git_push"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 10 "$branch" "$worktree"
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_implement 10 "Alpha" "$branch" "$worktree" 2>&1)"
+  assert_contains "retry reuses the existing worktree" "reusing worktree" "$output"
+  assert_eq "retry completes with a pr" "42" "$(jq -r '.[0].prNumber' "$TEST_STATE")"
+  assert_eq "retry transitions to awaiting review" "awaiting review" "$(jq -r '.[0].phase' "$TEST_STATE")"
+  assert_contains "retry pushes the preserved branch" "push -u origin ticket/10-alpha" "$(cat "$FAKE_GIT_PUSH_FILE")"
+  unset FAKE_GIT_PUSH_FILE
   state_teardown
 }
 
@@ -4388,6 +4551,7 @@ test_implement_fails_when_worktree_fails
 test_implement_fails_when_npm_ci_fails
 test_implement_retries_opencode_with_continue
 test_implement_escalates_after_two_opencode_failures
+test_implement_escalates_opencode_failure_preserves_commits
 test_implement_escalates_empty_run_without_resume
 test_implement_resumes_stalled_run_once_and_finishes
 test_implement_escalates_when_resume_still_commitless
@@ -4416,6 +4580,10 @@ test_poll_once_skips_when_cap_full
 test_poll_once_removes_entry_on_failed_implement
 test_poll_once_restores_ready_for_agent_on_failed_implement
 test_non_opencode_failure_escalates_at_bound
+test_non_opencode_failure_preserves_worktree_below_bound
+test_non_opencode_failure_at_bound_preserves_commits
+test_non_opencode_failure_clean_failure_still_cleans_up
+test_implement_reuses_existing_worktree_on_retry
 test_reconcile_skips_failed_entry
 test_poll_once_cleans_up_worktree_after_failed_implement
 test_poll_once_does_not_cleanup_preexisting_worktree


### PR DESCRIPTION
Automated implementation of #317.

---
_Created by carbotracker's agent skills._