### PR TITLE
Fix orchestrator merge resolution for advanced remote branches

### DIFF
--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -310,7 +310,7 @@ orchestrator_pr_merge_state() {
 # propagates its non-zero exit so callers can fail closed like the merge gate.
 orchestrator_pr_labels() {
   local pr="$1"
-  gh pr view "$pr" --json labels --jq '.[].name' 2>/dev/null
+  gh pr view "$pr" --json labels --jq '(.labels // []) | .[].name' 2>/dev/null
 }
 
 # True when a newline-separated label list carries the suspect-diff label
@@ -973,8 +973,25 @@ orchestrator_merge_behind_pr() {
 # the push proves nothing about the remote's current main, so re-fetch
 # origin/main and re-confirm it is still an ancestor of the branch tip. An
 # unverified push is never trusted.
+#
+# The remote branch itself may have advanced since the worktree last fetched it
+# (a human pushed fixes, or an earlier run landed) while origin/main moved too.
+# Without integrating that head the push would be rejected non-fast-forward and
+# the merge could never land, so the branch is fetched and merged in first; the
+# push is then a fast-forward. A conflict aborts cleanly and fails closed.
 orchestrator_merge_push_and_verify() {
   local branch="$1" worktree="$2" pr_number="$3"
+  if ! git -C "$worktree" fetch origin "$branch"; then
+    orchestrator_log "WARNING: failed to fetch origin/$branch for PR #$pr_number"
+    return 1
+  fi
+  if ! git -C "$worktree" merge-base --is-ancestor origin/"$branch" HEAD; then
+    if ! git -C "$worktree" merge --no-ff --no-edit origin/"$branch"; then
+      orchestrator_log "WARNING: origin/$branch conflicts with branch $branch for PR #$pr_number; aborting the merge"
+      git -C "$worktree" merge --abort 2>/dev/null || true
+      return 1
+    fi
+  fi
   if ! git -C "$worktree" push origin "$branch"; then
     orchestrator_log "WARNING: failed to push merged branch $branch for PR #$pr_number"
     return 1

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -471,13 +471,22 @@ exit 0"
 
 # Fake gh for the agent-driven conflict-resolution path: `pr view` reports an
 # OPEN PR whose mergeStateStatus is $1 (default DIRTY) and whose labels are $2
-# (one per line, as `--jq '.[].name'` emits), and an `api` call (the comment
-# POST) is appended to $FAKE_PR_COMMENT_ARGS.
+# (one per line). The labels branch rebuilds the realistic `--json labels`
+# document and runs the script's actual jq filter against it, so the fake
+# reproduces real gh's exit codes — a filter that cannot handle an unlabeled PR
+# fails the read exactly as production does. An `api` call (the comment POST)
+# is appended to $FAKE_PR_COMMENT_ARGS.
 fake_conflict_merge_gh() {
   local status="${1:-DIRTY}" labels="${2:-}"
+  local labels_json filter
+  labels_json='{"labels":[]}'
+  if [[ -n "$labels" ]]; then
+    labels_json="{\"labels\":[$(printf '%s\n' "$labels" | sed 's/.*/{"name":"&"}/' | paste -sd, -)]}"
+  fi
+  filter="$(sed -nE "s/.*--json labels --jq '([^']*)'.*/\1/p" "$ROOT/tools/ct-orchestrator.sh")"
   fake_command gh "if [[ \"\$1\" == \"pr\" && \"\$2\" == \"view\" ]]; then
   if [[ \"\$*\" == *\"--json mergeStateStatus\"* ]]; then printf \"$status\n\";
-  elif [[ \"\$*\" == *\"--json labels\"* ]]; then printf \"$labels\n\";
+  elif [[ \"\$*\" == *\"--json labels\"* ]]; then printf '%s' '$labels_json' | jq -r '$filter'; exit \"\${PIPESTATUS[1]}\";
   else printf \"OPEN\n\"; fi
 elif [[ \"\$1\" == \"api\" ]]; then
   printf \"%s\n\" \"\$*\" >> \"\${FAKE_PR_COMMENT_ARGS:-/dev/null}\"
@@ -486,16 +495,22 @@ exit 0"
 }
 
 # Fake git for the conflict-resolution path: fetch, merge-base, and push are
-# recorded to $FAKE_MERGE_GIT_ARGS; when $1 is not "yes" the ancestry check
-# fails (verify-before-push).
+# recorded to $FAKE_MERGE_GIT_ARGS. The ancestry checks are controlled
+# separately: $1 governs `merge-base --is-ancestor origin/main HEAD` (verify
+# that main merged in) and $2 governs the branch's own ancestry check
+# (`origin/ticket/...`), so a test can model the remote branch having advanced
+# while main stayed an ancestor. Both default to "yes".
 fake_conflict_merge_git() {
-  local ancestor="${1:-yes}"
+  local main_ancestor="${1:-yes}" branch_ancestor="${2:-yes}"
   fake_command git "if [[ \"\$1\" == \"-C\" ]]; then
   worktree=\"\$2\"
   shift 2
 fi
 printf \"%s %s\n\" \"\$worktree\" \"\$*\" >> \"\$FAKE_MERGE_GIT_ARGS\"
-if [[ \"\$1\" == \"merge-base\" && \"$ancestor\" != \"yes\" ]]; then exit 1; fi
+if [[ \"\$1\" == \"merge-base\" ]]; then
+  if [[ \"\$*\" == *\"origin/main\"* && \"$main_ancestor\" != \"yes\" ]]; then exit 1; fi
+  if [[ \"\$*\" == *\"origin/\"* && \"\$*\" != *\"origin/main\"* && \"$branch_ancestor\" != \"yes\" ]]; then exit 1; fi
+fi
 exit 0"
 }
 
@@ -3753,6 +3768,66 @@ exit 0'
   state_teardown
 }
 
+test_merge_poll_delegates_unlabeled_dirty_pr() {
+  state_setup
+  fake_conflict_merge_gh DIRTY ""
+  fake_conflict_merge_git
+  fake_merge_opencode_log "$STATE_DIR/opencode_log"
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_MERGE_GIT_ARGS="$STATE_DIR/git_args"
+  export FAKE_OPENCODE_LOG="$STATE_DIR/opencode_log"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_eq "unlabeled dirty pr is not a label-read failure" "0" "$(printf '%s' "$output" | grep -c 'could not read labels' || true)"
+  assert_eq "unlabeled dirty pr still runs the conflict-resolution agent" "1" "$(wc -l < "$FAKE_OPENCODE_LOG")"
+  assert_contains "unlabeled dirty pr is resolved and pushed" "agent resolved conflicts" "$output"
+  unset FAKE_MERGE_GIT_ARGS FAKE_OPENCODE_LOG
+  state_teardown
+}
+
+test_merge_poll_integrates_advanced_remote_branch() {
+  state_setup
+  fake_conflict_merge_gh DIRTY ""
+  fake_conflict_merge_git yes no
+  fake_merge_opencode "$STATE_DIR/opencode_args"
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_MERGE_GIT_ARGS="$STATE_DIR/git_args"
+  export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  local output
+  output="$(ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>&1)"
+  assert_contains "an advanced remote branch is fetched before pushing" "fetch origin ticket/123-foo" "$(cat "$FAKE_MERGE_GIT_ARGS")"
+  assert_contains "an advanced remote branch is merged into the branch" "merge --no-ff --no-edit origin/ticket/123-foo" "$(cat "$FAKE_MERGE_GIT_ARGS")"
+  assert_contains "the branch is still pushed after integrating the remote head" "push origin ticket/123-foo" "$(cat "$FAKE_MERGE_GIT_ARGS")"
+  assert_contains "integrating the advanced branch logs the verified push" "agent resolved conflicts" "$output"
+  assert_eq "integrating the advanced branch resets failures" "0" "$(jq -r '.[0].mergeFailures' "$TEST_STATE")"
+  unset FAKE_MERGE_GIT_ARGS FAKE_OPENCODE_ARGS
+  state_teardown
+}
+
+test_merge_poll_does_not_merge_when_branch_ancestor() {
+  state_setup
+  fake_conflict_merge_gh DIRTY ""
+  fake_conflict_merge_git
+  fake_merge_opencode "$STATE_DIR/opencode_args"
+  local worktree="$WT_PARENT/123-foo"
+  mkdir -p "$worktree"
+  export FAKE_MERGE_GIT_ARGS="$STATE_DIR/git_args"
+  export FAKE_OPENCODE_ARGS="$STATE_DIR/opencode_args"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_add "$TEST_STATE" 123 ticket/123-foo "$worktree"
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_state_complete "$TEST_STATE" 123 ses_abc 456
+  ORCHESTRATOR_STATE_FILE="$TEST_STATE" orchestrator_merge_poll 2>/dev/null
+  assert_eq "an already-ancestor remote branch is not merged again" "0" "$(grep -c 'merge --no-ff --no-edit origin/ticket/123-foo' "$FAKE_MERGE_GIT_ARGS" || true)"
+  assert_contains "an already-ancestor remote branch is still pushed" "push origin ticket/123-foo" "$(cat "$FAKE_MERGE_GIT_ARGS")"
+  unset FAKE_MERGE_GIT_ARGS FAKE_OPENCODE_ARGS
+  state_teardown
+}
+
 test_labels_are_suspect_pure_helper() {
   if orchestrator_labels_are_suspect "suspect-diff"; then
     pass "suspect-diff without approval is suspect"
@@ -4535,6 +4610,9 @@ test_merge_poll_bounds_agent_merges
 test_merge_poll_skips_suspect_pr
 test_merge_poll_skips_suspect_behind_pr
 test_merge_poll_fails_closed_when_labels_unreadable
+test_merge_poll_delegates_unlabeled_dirty_pr
+test_merge_poll_integrates_advanced_remote_branch
+test_merge_poll_does_not_merge_when_branch_ancestor
 test_labels_are_suspect_pure_helper
 test_merge_poll_delegation_requires_a_session
 test_merge_poll_retries_needs_human_comment


### PR DESCRIPTION
Fixes two orchestrator bugs found while debugging why PR #229 (ticket 225) could never resolve its merge conflict:

1. **Merge push rejected non-fast-forward forever.** `orchestrator_merge_push_and_verify` only fetched `origin/main` before pushing, never the remote *branch*. When the branch advanced externally (a human or earlier run pushing to it), every agent-merge push was rejected with `fetch first`, exhausting the 3 retries and posting a needs-human notice on a resolvable PR. It now fetches `origin/<branch>` and merges it in first (aborting cleanly on conflict), making the push a fast-forward for both the conflict and behind flows.

2. **Unlabeled PRs fail the label gate.** `gh pr view --json labels --jq '.[].name'` errors out on an unlabeled PR (empty `labels: []` array), so the merge gate fail-closed on every unlabeled DIRTY PR and never delegated resolution. The jq now defaults the labels to an empty array.

Tests: fake gh now runs the script's actual jq filter against realistic label JSON, and fake git distinguishes branch vs main ancestry. New coverage for unlabeled DIRTY PR delegation, advanced-remote-branch integration, and the no-op case. Full suite: 582 tests passed (34 fail against the old code).