### PR TITLE
Fix orchestrator missing review comments beyond first REST page

### DIFF
--- a/tools/ct-orchestrator.sh
+++ b/tools/ct-orchestrator.sh
@@ -336,13 +336,17 @@ orchestrator_pr_latest_comment_at() {
   # read that fails aborts the probe so a caller never mistakes an outage for
   # "no comments".
   me="$ORCHESTRATOR_AI_FOOTER_END_RE"
-  if ! inline_raw="$(orchestrator_gh "reading inline comments on PR #$pr" gh api "repos/{owner}/{repo}/pulls/$pr/comments")"; then
+  # The comment/review list endpoints default to 30 items per page, so a busy
+  # PR (many review rounds) silently drops newer comments beyond the first
+  # page and the daemon stops seeing review signals. Request the maximum page
+  # size so the whole surface is considered.
+  if ! inline_raw="$(orchestrator_gh "reading inline comments on PR #$pr" gh api "repos/{owner}/{repo}/pulls/$pr/comments?per_page=100")"; then
     return 1
   fi
-  if ! reviews_raw="$(orchestrator_gh "reading reviews on PR #$pr" gh api "repos/{owner}/{repo}/pulls/$pr/reviews")"; then
+  if ! reviews_raw="$(orchestrator_gh "reading reviews on PR #$pr" gh api "repos/{owner}/{repo}/pulls/$pr/reviews?per_page=100")"; then
     return 1
   fi
-  if ! general_raw="$(orchestrator_gh "reading general comments on PR #$pr" gh api "repos/{owner}/{repo}/issues/$pr/comments")"; then
+  if ! general_raw="$(orchestrator_gh "reading general comments on PR #$pr" gh api "repos/{owner}/{repo}/issues/$pr/comments?per_page=100")"; then
     return 1
   fi
   inline="$(printf '%s' "$inline_raw" | jq -r --arg me "$me" "[.[] | $ORCHESTRATOR_REVIEW_SIGNAL_JQ | .created_at] | max // empty" 2>/dev/null || true)"
@@ -670,7 +674,7 @@ orchestrator_review_implement_verified() {
   local worktree="$1" pr="$2" plan_file="$3" before_ids="$4"
   local state replies
   state="$(orchestrator_review_threads_state "$worktree" "$pr")" || return 1
-  replies="$(cd "$worktree" && gh api "repos/{owner}/{repo}/pulls/$pr/comments" 2>/dev/null || true)"
+  replies="$(cd "$worktree" && gh api "repos/{owner}/{repo}/pulls/$pr/comments?per_page=100" 2>/dev/null || true)"
   if [[ -z "$replies" ]]; then
     return 1
   fi
@@ -720,7 +724,7 @@ orchestrator_review_threads_state() {
 # Used to verify a general implement comment gained a reply during the run.
 orchestrator_pr_agent_general_comment_ids() {
   local worktree="$1" pr="$2"
-  (cd "$worktree" && gh api "repos/{owner}/{repo}/issues/$pr/comments" 2>/dev/null \
+  (cd "$worktree" && gh api "repos/{owner}/{repo}/issues/$pr/comments?per_page=100" 2>/dev/null \
     | jq -r --arg me "$ORCHESTRATOR_AI_FOOTER_END_RE" \
         '[.[] | select((.body // "") | test($me)) | .id] | join(",")' 2>/dev/null || true)
 }

--- a/tools/tests/ct-orchestrator.test.sh
+++ b/tools/tests/ct-orchestrator.test.sh
@@ -2133,6 +2133,29 @@ exit 0'
   assert_eq "no comments returns empty" "" "$(orchestrator_pr_latest_comment_at 100)"
 }
 
+test_pr_latest_comment_at_sees_more_than_one_page() {
+  # The comment list endpoint defaults to 30 items per page; without
+  # per_page=100 a busy PR silently drops newer comments beyond the first
+  # page and the daemon never sees the newest review signal. 35 comments on
+  # the pulls surface means the newest (index 34) must still win the
+  # watermark.
+  fake_command gh 'if [[ "$1" == "api" ]]; then
+  case "$2" in
+    *reviews*) printf "[]\n" ;;
+    *pulls/*comments*) printf "["
+      for i in $(seq 0 34); do
+        if [[ $i -gt 0 ]]; then printf ","; fi
+        printf "{\"created_at\":\"2026-08-13T00:%02d:00Z\",\"user\":{\"type\":\"User\"},\"body\":\"comment %d\"}" "$i" "$i"
+      done
+      printf "]\n" ;;
+    *pulls/*) printf "[]\n" ;;
+    *issues/*comments*) printf "[]\n" ;;
+  esac
+fi
+exit 0'
+  assert_eq "comments beyond the first REST page still move the watermark" "2026-08-13T00:34:00Z" "$(orchestrator_pr_latest_comment_at 100)"
+}
+
 test_pr_latest_comment_at_one_surface_empty() {
   fake_command gh 'if [[ "$1" == "api" ]]; then
   case "$2" in
@@ -4524,6 +4547,7 @@ test_reconcile_nothing_recoverable_cleans_up
 test_pr_number_for_branch
 test_pr_number_for_branch_missing
 test_pr_latest_comment_at_returns_newest
+test_pr_latest_comment_at_sees_more_than_one_page
 test_pr_latest_comment_at_prefers_general_when_newer
 test_pr_latest_comment_at_includes_review_submission
 test_pr_latest_comment_at_ignores_pending_reviews


### PR DESCRIPTION
## Problem

The daemon's review watermark is computed from three `gh api` list calls, and GitHub REST list endpoints default to **30 items per page** with no pagination. A busy PR that accumulates more than 30 comments on any surface silently drops the newer comments, so the daemon stops seeing the latest review signal and never acts on it.

PR #229 hit this exactly: **36 inline comments** pushed the human reviewer's newest comment past the first page, freezing the watermark at `2026-08-17T23:08:18Z` while the true newest human comment was `2026-08-19T17:28:04Z`. Every poll logged "no new comment" because the newest comments were invisible to it.

## Fix

Request `per_page=100` (GitHub's maximum) on:

- the three watermark queries in `orchestrator_pr_latest_comment_at` (inline threads, review submissions, general comments), and
- the two other comment-read sites sharing the gap: the implement-verify reply scan and the agent general-comment id scan.

Keeping the query string on the URL preserves arg positions, so existing `gh` mocks keep matching.

## Verification

- Regression test `test_pr_latest_comment_at_sees_more_than_one_page` feeds 35 comments through the pulls surface and asserts the newest (beyond page 30) still wins the watermark.
- Full suite: **583/583 passing**.
- Against the real PR #229: inline 36, reviews 33, general 6 all returned; the watermark with the fix moves to `2026-08-19T17:28:04Z`.