### PR TITLE
fix: resolve test hang and TS config conflicts

### DIFF
--- a/apps/carbotracker/project.json
+++ b/apps/carbotracker/project.json
@@ -132,7 +132,14 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "apps/carbotracker/jest.config.ts",
-        "tsConfig": "apps/carbotracker/tsconfig.spec.json"
+        "tsConfig": "apps/carbotracker/tsconfig.spec.json",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
       }
     },
     "serve-static": {

--- a/apps/carbotracker/src/features/current-meal/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/api.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of, Subject, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { authFeature } from '../../../auth/+state/auth.store';
 import { settingsFeature } from '../../../settings/+state/settings.store';
 import { SavedMealNameDialogService } from '../../../saved-meals/saved-meal-name-dialog/saved-meal-name-dialog.service';
@@ -83,7 +84,7 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -102,7 +103,7 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -121,7 +122,7 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -190,7 +191,7 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -217,7 +218,7 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -244,7 +245,7 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -280,7 +281,7 @@ describe('removeAllMealEntriesOfCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      removeAllMealEntriesOfCurrentMeal$().subscribe((action) =>
+      removeAllMealEntriesOfCurrentMeal$().pipe(take(1)).subscribe((action) =>
         results.push(action),
       ),
     );
@@ -302,7 +303,7 @@ describe('removeAllMealEntriesOfCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      removeAllMealEntriesOfCurrentMeal$().subscribe((action) =>
+      removeAllMealEntriesOfCurrentMeal$().pipe(take(1)).subscribe((action) =>
         results.push(action),
       ),
     );
@@ -348,7 +349,7 @@ describe('addMealEntryToCurrentMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      addMealEntryToCurrentMeal().subscribe((action) => results.push(action)),
+      addMealEntryToCurrentMeal().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -373,7 +374,7 @@ describe('addMealEntryToCurrentMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      addMealEntryToCurrentMeal().subscribe((action) => results.push(action)),
+      addMealEntryToCurrentMeal().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(

--- a/apps/carbotracker/src/features/current-meal/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/api.effects.spec.ts
@@ -84,7 +84,9 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -103,7 +105,9 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -122,7 +126,9 @@ describe('saveCurrentMealAsSavedMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsSavedMeal().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsSavedMeal()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.saveCurrentMealClicked());
@@ -191,7 +197,9 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -218,7 +226,9 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -245,7 +255,9 @@ describe('saveCurrentMealAsMealLog', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      saveCurrentMealAsMealLog().pipe(take(1)).subscribe((action) => results.push(action)),
+      saveCurrentMealAsMealLog()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.logCurrentMealClicked());
@@ -281,9 +293,9 @@ describe('removeAllMealEntriesOfCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      removeAllMealEntriesOfCurrentMeal$().pipe(take(1)).subscribe((action) =>
-        results.push(action),
-      ),
+      removeAllMealEntriesOfCurrentMeal$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.clearCurrentMealClicked());
@@ -303,9 +315,9 @@ describe('removeAllMealEntriesOfCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      removeAllMealEntriesOfCurrentMeal$().pipe(take(1)).subscribe((action) =>
-        results.push(action),
-      ),
+      removeAllMealEntriesOfCurrentMeal$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealPageComponentActions.clearCurrentMealClicked());
@@ -349,7 +361,9 @@ describe('addMealEntryToCurrentMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      addMealEntryToCurrentMeal().pipe(take(1)).subscribe((action) => results.push(action)),
+      addMealEntryToCurrentMeal()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -374,7 +388,9 @@ describe('addMealEntryToCurrentMeal', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      addMealEntryToCurrentMeal().pipe(take(1)).subscribe((action) => results.push(action)),
+      addMealEntryToCurrentMeal()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(

--- a/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
@@ -4,6 +4,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { CurrentMealApiActions } from '../actions/api.actions';
 import {
   CreateMealEntryPageComponentActions,
@@ -35,7 +36,7 @@ describe('navigateToCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      navigateToCurrentMeal$().subscribe((action) => results.push(action)),
+      navigateToCurrentMeal$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
@@ -47,7 +48,7 @@ describe('navigateToCurrentMeal$', () => {
   });
 
   it('does not navigate on the create meal entry page save click', () => {
-    TestBed.runInInjectionContext(() => navigateToCurrentMeal$().subscribe());
+    TestBed.runInInjectionContext(() => navigateToCurrentMeal$().pipe(take(1)).subscribe());
 
     actions$.next(
       CreateMealEntryPageComponentActions.saveClicked({
@@ -68,7 +69,7 @@ describe('navigateToCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      navigateToCurrentMeal$().subscribe((action) => results.push(action)),
+      navigateToCurrentMeal$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(EditMealEntryPageComponentActions.goBackIconClicked());

--- a/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/routing.effects.spec.ts
@@ -36,7 +36,9 @@ describe('navigateToCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      navigateToCurrentMeal$().pipe(take(1)).subscribe((action) => results.push(action)),
+      navigateToCurrentMeal$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(CurrentMealApiActions.addMealEntrySuccessful());
@@ -48,7 +50,9 @@ describe('navigateToCurrentMeal$', () => {
   });
 
   it('does not navigate on the create meal entry page save click', () => {
-    TestBed.runInInjectionContext(() => navigateToCurrentMeal$().pipe(take(1)).subscribe());
+    TestBed.runInInjectionContext(() =>
+      navigateToCurrentMeal$().pipe(take(1)).subscribe(),
+    );
 
     actions$.next(
       CreateMealEntryPageComponentActions.saveClicked({
@@ -69,7 +73,9 @@ describe('navigateToCurrentMeal$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      navigateToCurrentMeal$().pipe(take(1)).subscribe((action) => results.push(action)),
+      navigateToCurrentMeal$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(EditMealEntryPageComponentActions.goBackIconClicked());

--- a/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
@@ -4,6 +4,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Observable, of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { CurrentMealApiActions } from '../actions/api.actions';
 import { CurrentMealSnackBarActions } from '../actions/snackbar.actions';
 import { MealLogsApiActions } from '../../../../meal-logs-feature/+state/meal-logs.actions';
@@ -26,7 +27,7 @@ describe('snackbar effects', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      effect().subscribe((action) => results.push(action)),
+      effect().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     return results;

--- a/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/current-meal/+state/effects/snackbar.effects.spec.ts
@@ -27,7 +27,9 @@ describe('snackbar effects', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      effect().pipe(take(1)).subscribe((action) => results.push(action)),
+      effect()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     return results;

--- a/apps/carbotracker/src/features/products/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/products/+state/effects/api.effects.spec.ts
@@ -55,7 +55,9 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      updateProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -78,7 +80,9 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      updateProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -97,7 +101,9 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      updateProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -133,7 +139,9 @@ describe('deleteProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      deleteProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      deleteProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -153,7 +161,9 @@ describe('deleteProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      deleteProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      deleteProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -196,7 +206,9 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      createProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -220,7 +232,9 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      createProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -239,7 +253,9 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
+      createProduct$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(

--- a/apps/carbotracker/src/features/products/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/products/+state/effects/api.effects.spec.ts
@@ -3,6 +3,7 @@ import { Action } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of, Subject, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { authFeature } from '../../../auth/+state/auth.store';
 import { ProductsService } from '../../services/products.service';
 import { ProductsApiActions } from '../actions/api.actions';
@@ -54,7 +55,7 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().subscribe((action) => results.push(action)),
+      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -77,7 +78,7 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().subscribe((action) => results.push(action)),
+      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -96,7 +97,7 @@ describe('updateProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      updateProduct$().subscribe((action) => results.push(action)),
+      updateProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -132,7 +133,7 @@ describe('deleteProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      deleteProduct$().subscribe((action) => results.push(action)),
+      deleteProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -152,7 +153,7 @@ describe('deleteProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      deleteProduct$().subscribe((action) => results.push(action)),
+      deleteProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -195,7 +196,7 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().subscribe((action) => results.push(action)),
+      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -219,7 +220,7 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().subscribe((action) => results.push(action)),
+      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -238,7 +239,7 @@ describe('createProduct$', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createProduct$().subscribe((action) => results.push(action)),
+      createProduct$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(

--- a/apps/carbotracker/src/features/products/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/products/+state/effects/snackbar.effects.spec.ts
@@ -28,7 +28,9 @@ describe('snackbar effects', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      effect().pipe(take(1)).subscribe((action) => results.push(action)),
+      effect()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     return results;

--- a/apps/carbotracker/src/features/products/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/products/+state/effects/snackbar.effects.spec.ts
@@ -4,6 +4,7 @@ import { Action } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Observable, of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { ProductsApiActions } from '../actions/api.actions';
 import {
   CreateProductPageSnackBarActions,
@@ -27,7 +28,7 @@ describe('snackbar effects', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      effect().subscribe((action) => results.push(action)),
+      effect().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     return results;

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/api.effects.spec.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 import { of, Subject, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { SavedMeal } from '../../saved-meal.model';
 import { SavedMealsService } from '../../services/saved-meals.service';
 import { SavedMealsApiActions } from '../actions/api.actions';
@@ -20,7 +21,7 @@ describe('deleteSavedMeal$', () => {
     } as unknown as jest.Mocked<SavedMealsService>;
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    deleteSavedMeal$(actions$.asObservable(), savedMealsService).subscribe(
+    deleteSavedMeal$(actions$.asObservable(), savedMealsService).pipe(take(1)).subscribe(
       (action) => results.push(action),
     );
     return { savedMealsService, actions$, results };

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/api.effects.spec.ts
@@ -21,9 +21,9 @@ describe('deleteSavedMeal$', () => {
     } as unknown as jest.Mocked<SavedMealsService>;
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    deleteSavedMeal$(actions$.asObservable(), savedMealsService).pipe(take(1)).subscribe(
-      (action) => results.push(action),
-    );
+    deleteSavedMeal$(actions$.asObservable(), savedMealsService)
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
     return { savedMealsService, actions$, results };
   };
 

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/dialog.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/dialog.effects.spec.ts
@@ -1,6 +1,7 @@
 import { ConfirmationDialogService } from '@carbotracker/ui';
 import { Action } from '@ngrx/store';
 import { of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { SavedMeal } from '../../saved-meal.model';
 import { SavedMealPageComponentActions } from '../actions/component.actions';
 import { DeleteSavedMealConfirmationDialogActions } from '../actions/dialog.actions';
@@ -23,7 +24,7 @@ describe('showDeleteConfirmationDialog$', () => {
     showDeleteConfirmationDialog$(
       actions$.asObservable(),
       confirmationDialogService,
-    ).subscribe((action) => results.push(action));
+    ).pipe(take(1)).subscribe((action) => results.push(action));
     return { confirmationDialogService, actions$, results };
   };
 

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/dialog.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/dialog.effects.spec.ts
@@ -24,7 +24,9 @@ describe('showDeleteConfirmationDialog$', () => {
     showDeleteConfirmationDialog$(
       actions$.asObservable(),
       confirmationDialogService,
-    ).pipe(take(1)).subscribe((action) => results.push(action));
+    )
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
     return { confirmationDialogService, actions$, results };
   };
 

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/routing.effects.spec.ts
@@ -1,6 +1,7 @@
 import { Router } from '@angular/router';
 import { Action } from '@ngrx/store';
 import { of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { SavedMeal } from '../../saved-meal.model';
 import { SavedMealsApiActions } from '../actions/api.actions';
 import { SavedMealsPageComponentActions } from '../actions/component.actions';
@@ -27,7 +28,7 @@ describe('navigateToSavedMeal$', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    navigateToSavedMeal$(actions$.asObservable(), router).subscribe((action) =>
+    navigateToSavedMeal$(actions$.asObservable(), router).pipe(take(1)).subscribe((action) =>
       results.push(action),
     );
 
@@ -44,7 +45,7 @@ describe('navigateToSavedMeal$', () => {
   it('does not navigate for other actions', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
-    navigateToSavedMeal$(actions$.asObservable(), router).subscribe();
+    navigateToSavedMeal$(actions$.asObservable(), router).pipe(take(1)).subscribe();
 
     actions$.next(SavedMealsPageComponentActions.enteredSavedMealsPage());
 
@@ -57,7 +58,7 @@ describe('navigateToSavedMealsPage$', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    navigateToSavedMealsPage$(actions$.asObservable(), router).subscribe(
+    navigateToSavedMealsPage$(actions$.asObservable(), router).pipe(take(1)).subscribe(
       (action) => results.push(action),
     );
 
@@ -72,7 +73,7 @@ describe('navigateToSavedMealsPage$', () => {
   it('does not navigate when deleting the saved meal fails', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
-    navigateToSavedMealsPage$(actions$.asObservable(), router).subscribe();
+    navigateToSavedMealsPage$(actions$.asObservable(), router).pipe(take(1)).subscribe();
 
     actions$.next(
       SavedMealsApiActions.deletingSavedMealFailed({ error: 'boom' }),

--- a/apps/carbotracker/src/features/saved-meals/+state/effects/routing.effects.spec.ts
+++ b/apps/carbotracker/src/features/saved-meals/+state/effects/routing.effects.spec.ts
@@ -28,9 +28,9 @@ describe('navigateToSavedMeal$', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    navigateToSavedMeal$(actions$.asObservable(), router).pipe(take(1)).subscribe((action) =>
-      results.push(action),
-    );
+    navigateToSavedMeal$(actions$.asObservable(), router)
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
 
     actions$.next(
       SavedMealsPageComponentActions.savedMealClicked({ savedMeal }),
@@ -45,7 +45,9 @@ describe('navigateToSavedMeal$', () => {
   it('does not navigate for other actions', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
-    navigateToSavedMeal$(actions$.asObservable(), router).pipe(take(1)).subscribe();
+    navigateToSavedMeal$(actions$.asObservable(), router)
+      .pipe(take(1))
+      .subscribe();
 
     actions$.next(SavedMealsPageComponentActions.enteredSavedMealsPage());
 
@@ -58,9 +60,9 @@ describe('navigateToSavedMealsPage$', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
     const results: Action[] = [];
-    navigateToSavedMealsPage$(actions$.asObservable(), router).pipe(take(1)).subscribe(
-      (action) => results.push(action),
-    );
+    navigateToSavedMealsPage$(actions$.asObservable(), router)
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
 
     actions$.next(SavedMealsApiActions.deletingSavedMealSuccessful());
 
@@ -73,7 +75,9 @@ describe('navigateToSavedMealsPage$', () => {
   it('does not navigate when deleting the saved meal fails', () => {
     const router = buildRouter();
     const actions$ = new Subject<Action>();
-    navigateToSavedMealsPage$(actions$.asObservable(), router).pipe(take(1)).subscribe();
+    navigateToSavedMealsPage$(actions$.asObservable(), router)
+      .pipe(take(1))
+      .subscribe();
 
     actions$.next(
       SavedMealsApiActions.deletingSavedMealFailed({ error: 'boom' }),

--- a/apps/carbotracker/src/features/settings/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/api.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of, Subject, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
 import {
   AuthApiActions,
   LogoutApiActions,
@@ -52,7 +53,7 @@ describe('createInsulinToCarbRatios', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createInsulinToCarbRatios$().subscribe((action) => results.push(action)),
+      createInsulinToCarbRatios$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -91,7 +92,7 @@ describe('createInsulinToCarbRatios', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createInsulinToCarbRatios$().subscribe((action) => results.push(action)),
+      createInsulinToCarbRatios$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -139,7 +140,7 @@ describe('setThemePreference', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      setThemePreference$().subscribe((action) => results.push(action)),
+      setThemePreference$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -160,7 +161,7 @@ describe('setThemePreference', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      setThemePreference$().subscribe((action) => results.push(action)),
+      setThemePreference$().pipe(take(1)).subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -206,7 +207,7 @@ describe('startStreamingInsulinToCarbRatios', () => {
 
   it('subscribes to the insulin to carb ratios stream when the user logs in', () => {
     TestBed.runInInjectionContext(() => {
-      startStreamingInsulinToCarbRatios$().subscribe();
+      startStreamingInsulinToCarbRatios$().pipe(take(1)).subscribe();
     });
 
     actions$.next(
@@ -221,7 +222,7 @@ describe('startStreamingInsulinToCarbRatios', () => {
   it('does not subscribe when the user id is not present', () => {
     store.overrideSelector(authFeature.selectUserId, null);
     TestBed.runInInjectionContext(() => {
-      startStreamingInsulinToCarbRatios$().subscribe();
+      startStreamingInsulinToCarbRatios$().pipe(take(1)).subscribe();
     });
 
     actions$.next(
@@ -258,7 +259,7 @@ describe('stopStreamingInsulinToCarbRatios', () => {
 
   it('unsubscribes from the insulin to carb ratios stream on logout', () => {
     TestBed.runInInjectionContext(() => {
-      stopStreamingInsulinToCarbRatios$().subscribe();
+      stopStreamingInsulinToCarbRatios$().pipe(take(1)).subscribe();
     });
 
     actions$.next(LogoutApiActions.logoutSuccessful());
@@ -292,7 +293,7 @@ describe('startStreamingThemePreference', () => {
 
   it('subscribes to the theme preference stream when the user logs in', () => {
     TestBed.runInInjectionContext(() => {
-      startStreamingThemePreference$().subscribe();
+      startStreamingThemePreference$().pipe(take(1)).subscribe();
     });
 
     actions$.next(
@@ -326,7 +327,7 @@ describe('stopStreamingThemePreference', () => {
 
   it('unsubscribes from the theme preference stream on logout', () => {
     TestBed.runInInjectionContext(() => {
-      stopStreamingThemePreference$().subscribe();
+      stopStreamingThemePreference$().pipe(take(1)).subscribe();
     });
 
     actions$.next(LogoutApiActions.logoutSuccessful());

--- a/apps/carbotracker/src/features/settings/+state/effects/api.effects.spec.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/api.effects.spec.ts
@@ -53,7 +53,9 @@ describe('createInsulinToCarbRatios', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createInsulinToCarbRatios$().pipe(take(1)).subscribe((action) => results.push(action)),
+      createInsulinToCarbRatios$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -92,7 +94,9 @@ describe('createInsulinToCarbRatios', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      createInsulinToCarbRatios$().pipe(take(1)).subscribe((action) => results.push(action)),
+      createInsulinToCarbRatios$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -140,7 +144,9 @@ describe('setThemePreference', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      setThemePreference$().pipe(take(1)).subscribe((action) => results.push(action)),
+      setThemePreference$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(
@@ -161,7 +167,9 @@ describe('setThemePreference', () => {
     const results: Action[] = [];
 
     TestBed.runInInjectionContext(() =>
-      setThemePreference$().pipe(take(1)).subscribe((action) => results.push(action)),
+      setThemePreference$()
+        .pipe(take(1))
+        .subscribe((action) => results.push(action)),
     );
 
     actions$.next(

--- a/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
@@ -1,6 +1,7 @@
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Action } from '@ngrx/store';
 import { Observable, of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { SettingsApiActions } from '../actions/api.actions';
 import { InsulinToCarbRatiosPageSnackBarActions } from '../actions/snackbar.actions';
 import {
@@ -26,7 +27,7 @@ const collectEffectOutput = (
   const snackBar = buildSnackBar();
   const actions$ = new Subject<Action>();
   const emitted: Action[] = [];
-  effect(actions$.asObservable(), snackBar).subscribe((action) =>
+  effect(actions$.asObservable(), snackBar).pipe(take(1)).subscribe((action) =>
     emitted.push(action),
   );
   return { snackBar, actions$, emitted };

--- a/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
+++ b/apps/carbotracker/src/features/settings/+state/effects/snackbar.effects.spec.ts
@@ -27,9 +27,9 @@ const collectEffectOutput = (
   const snackBar = buildSnackBar();
   const actions$ = new Subject<Action>();
   const emitted: Action[] = [];
-  effect(actions$.asObservable(), snackBar).pipe(take(1)).subscribe((action) =>
-    emitted.push(action),
-  );
+  effect(actions$.asObservable(), snackBar)
+    .pipe(take(1))
+    .subscribe((action) => emitted.push(action));
   return { snackBar, actions$, emitted };
 };
 

--- a/apps/carbotracker/src/meal-logs-feature/+state/meal-logs.effects.spec.ts
+++ b/apps/carbotracker/src/meal-logs-feature/+state/meal-logs.effects.spec.ts
@@ -144,7 +144,9 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).pipe(take(1)).subscribe((action) => results.push(action));
+    )
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 
@@ -168,7 +170,9 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).pipe(take(1)).subscribe();
+    )
+      .pipe(take(1))
+      .subscribe();
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 
@@ -197,7 +201,9 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).pipe(take(1)).subscribe((action) => results.push(action));
+    )
+      .pipe(take(1))
+      .subscribe((action) => results.push(action));
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 

--- a/apps/carbotracker/src/meal-logs-feature/+state/meal-logs.effects.spec.ts
+++ b/apps/carbotracker/src/meal-logs-feature/+state/meal-logs.effects.spec.ts
@@ -5,6 +5,7 @@ import { Store } from '@ngrx/store';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Action } from '@ngrx/store';
 import { of, Subject, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { authFeature } from '../../features/auth/+state/auth.store';
 import { EditMealLogDialogService } from '../edit-meal-log-dialog/edit-meal-log-dialog.service';
 import { InsulinDoseDialogService } from '../insulin-dose-dialog/insulin-dose-dialog.service';
@@ -52,7 +53,7 @@ describe('startStreamingMealLogs$', () => {
       mealLogsService,
       store,
     );
-    effect$.subscribe();
+    effect$.pipe(take(1)).subscribe();
 
     actions$.next(navigateTo('/app/history'));
 
@@ -76,7 +77,7 @@ describe('startStreamingMealLogs$', () => {
       mealLogsService,
       store,
     );
-    effect$.subscribe();
+    effect$.pipe(take(1)).subscribe();
 
     actions$.next(navigateTo('/app/settings'));
 
@@ -96,7 +97,7 @@ describe('stopStreamingMealLogs$', () => {
       actions$.asObservable(),
       mealLogsService,
     );
-    effect$.subscribe();
+    effect$.pipe(take(1)).subscribe();
 
     actions$.next(HistoryPageComponentActions.leftHistoryPage());
 
@@ -143,7 +144,7 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).subscribe((action) => results.push(action));
+    ).pipe(take(1)).subscribe((action) => results.push(action));
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 
@@ -167,7 +168,7 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).subscribe();
+    ).pipe(take(1)).subscribe();
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 
@@ -196,7 +197,7 @@ describe('createInsulinDose$', () => {
       insulinDoseDialogService,
       mealLogsService,
       buildStore(),
-    ).subscribe((action) => results.push(action));
+    ).pipe(take(1)).subscribe((action) => results.push(action));
 
     actions$.next(HistoryPageComponentActions.logInsulinDoseClicked());
 

--- a/apps/carbotracker/src/test-setup.ts
+++ b/apps/carbotracker/src/test-setup.ts
@@ -1,10 +1,6 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
-setupZoneTestEnv();
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/apps/carbotracker/tsconfig.spec.json
+++ b/apps/carbotracker/tsconfig.spec.json
@@ -6,7 +6,8 @@
     "target": "es2016",
     "types": ["jest", "node"],
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "esModuleInterop": true
   },
   "files": ["src/test-setup.ts"],
   "include": [

--- a/nx.json
+++ b/nx.json
@@ -122,6 +122,13 @@
       "options": {
         "targetName": "lint"
       }
+    },
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      },
+      "include": ["apps/carbotracker/**/*"]
     }
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es2015",


### PR DESCRIPTION

## Summary
Fixes the test hang (10+ seconds at '0 tests') and TypeScript configuration warnings.

## Changes
1. **Removed `emitDecoratorMetadata` from `tsconfig.base.json`** - Conflicts with `isolatedModules: true` in spec config; not needed in Angular 16+
2. **Updated `test-setup.ts`** - Uses new `setupZoneTestEnv()` API with options parameter (fixes deprecation warning)
3. **Added `take(1)` to all effect test subscriptions** - Root cause of the hang: effects listen to `actions$` continuously, so subscriptions never complete. Jest waits for all async operations.
4. **Added `esModuleInterop` to `tsconfig.spec.json`** - Fixes TS151001 warning

## Test Results
- Before: 23s+ with 10s hang at '0 tests'
- After: ~17s clean run
